### PR TITLE
Fix: multiple gets generates error

### DIFF
--- a/api/v01/vrp.rb
+++ b/api/v01/vrp.rb
@@ -610,7 +610,7 @@ module Api
             output_format = params[:format]&.to_sym || ((solution && solution['csv']) ? :csv : env['api.format'])
             env['api.format'] = output_format # To override json default format
 
-            if job.completed?
+            if job&.completed? # job can still be nil if we have the solution from the dump
               OptimizerWrapper.job_remove(params[:api_key], id)
               APIBase.dump_vrp_dir.write([id, params[:api_key], 'solution'].join('_'), Marshal.dump(solution)) if stored_result.nil? && OptimizerWrapper.config[:dump][:solution]
             end
@@ -624,8 +624,8 @@ module Api
                 solutions: [solution['result']].flatten(1),
                 job: {
                   id: id,
-                  status: job.status.to_sym, # :queued, :working, :completed, #failed
-                  avancement: job.message,
+                  status: job&.status&.to_sym || :completed, # :queued, :working, :completed, :failed
+                  avancement: job&.message,
                   graph: solution['graph']
                 }
               }, with: Grape::Presenters::Presenter)

--- a/test/api/v01/vrp_test.rb
+++ b/test/api/v01/vrp_test.rb
@@ -201,6 +201,21 @@ class Api::V01::VrpTest < Api::V01::RequestHelper
     delete_job @job_id, api_key: 'demo'
   end
 
+  def test_get_completed_job_with_solution_dump
+    old_config_dump_solution = OptimizerWrapper.config[:dump][:solution]
+    OptimizerWrapper.config[:dump][:solution] = true
+    TestHelper.solve_asynchronously do
+      @job_id = submit_vrp api_key: 'demo', vrp: VRP.toy
+      wait_status @job_id, 'completed', api_key: 'demo'
+    end
+
+    get "/0.1/vrp/jobs/#{@job_id}", api_key: 'demo'
+    assert_equal 200, last_response.status, last_response.body
+    assert_equal 'completed', JSON.parse(last_response.body)['job']['status'], last_response.body
+  ensure
+    OptimizerWrapper.config[:dump][:solution] = old_config_dump_solution
+  end
+
   def test_block_call_under_clustering
     @job_ids = []
     TestHelper.solve_asynchronously do


### PR DESCRIPTION
When there is a solution dump, `job` is nil..