### PR TITLE
Use the latest balanced_vrp_clustering gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,12 @@ GIT
 
 GIT
   remote: git://github.com/Mapotempo/balanced_vrp_clustering.git
-  revision: bae92bf1979892de3ba704ce75bc2e2d8efa284e
+  revision: 638af8b4ddd8efab89e480ae2be435fb88a8f13a
   branch: dev
   specs:
-    balanced_vrp_clustering (0.1.3)
+    balanced_vrp_clustering (0.1.5)
+      color-generator
+      geojson2image
 
 GEM
   remote: https://rubygems.org/
@@ -35,8 +37,10 @@ GEM
     builder (3.2.3)
     byebug (11.0.1)
     charlock_holmes (0.7.7)
+    chunky_png (1.3.12)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    color-generator (0.0.4)
     concurrent-ruby (1.1.5)
     daemons (1.3.1)
     descendants_tracker (0.0.4)
@@ -46,6 +50,9 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     eventmachine (1.2.7)
+    geojson2image (0.2.2)
+      chunky_png (~> 1.3)
+      oj (~> 3.6)
     google-protobuf (3.9.1)
     grape (0.18.0)
       activesupport
@@ -112,6 +119,7 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    oj (3.10.8)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -595,6 +595,7 @@ class SplitClusteringTest < Minitest::Test
 
     def test_max_split_functionality
       vrp = TestHelper.load_vrp(self)
+      vrp.resolution_duration = 120000
 
       Interpreters::Dichotomious.stub(:dichotomious_candidate?, ->(_service_vrp){ return false }) do # stub dicho so that it doesn't pass trough it
         result = OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:ortools] }}, vrp, nil)


### PR DESCRIPTION
add_geojsonoutput_smallfixes_codequality
Last corrections before the balancing implementation.
The performance is validated by usual scheduling instances.
This PR sets the base for the multi-depot implementation.