### PR TITLE
[SCHED] Improve impossible lapse detection

### DIFF
--- a/models/concerns/periodic_service.rb
+++ b/models/concerns/periodic_service.rb
@@ -24,27 +24,26 @@ module PeriodicService
   def can_affect_all_visits?(service)
     return true if service.visits_number == 1
 
-    current_day = self.schedule_range_indices[:start]
-    decimal_day = current_day
-    current_visit = 0
-    while current_visit < service.visits_number && current_day <= self.schedule_range_indices[:end]
-      potential_vehicle = self.vehicles.find{ |v|
-        !v.unavailable_work_day_indices.include?(current_day) &&
-          (v.timewindow.nil? && v.sequence_timewindows.empty? ||
-          v.timewindow && (v.timewindow.day_index.nil? || current_day % 7 == v.timewindow.day_index) ||
-          v.sequence_timewindows.any?{ |tw| tw.day_index.nil? || current_day % 7 == tw.day_index })
-      }
+    self.vehicles.any?{ |vehicle|
+      current_day = self.schedule_range_indices[:start]
+      decimal_day = current_day
+      current_visit = 0
 
-      if potential_vehicle
-        decimal_day += (service.minimum_lapse || 1)
-        current_day = decimal_day.round
-        current_visit += 1
-      else
-        decimal_day += 1
-        current_day += 1
+      while current_visit < service.visits_number && current_day <= self.schedule_range_indices[:end]
+          if !vehicle.unavailable_work_day_indices.include?(current_day) &&
+             (vehicle.timewindow.nil? && vehicle.sequence_timewindows.empty? ||
+             (vehicle.timewindow && (vehicle.timewindow.day_index.nil? || current_day % 7 == vehicle.timewindow.day_index)) ||
+             (vehicle.sequence_timewindows.any?{ |tw| tw.day_index.nil? || current_day % 7 == tw.day_index }))
+          decimal_day += (service.minimum_lapse || 1)
+          current_day = decimal_day.round
+          current_visit += 1
+        else
+          decimal_day += 1
+          current_day += 1
+        end
       end
-    end
 
-    current_visit == service.visits_number
+      current_visit == service.visits_number
+    }
   end
 end

--- a/models/concerns/periodic_service.rb
+++ b/models/concerns/periodic_service.rb
@@ -30,10 +30,10 @@ module PeriodicService
       current_visit = 0
 
       while current_visit < service.visits_number && current_day <= self.schedule_range_indices[:end]
-          if !vehicle.unavailable_work_day_indices.include?(current_day) &&
-             (vehicle.timewindow.nil? && vehicle.sequence_timewindows.empty? ||
-             (vehicle.timewindow && (vehicle.timewindow.day_index.nil? || current_day % 7 == vehicle.timewindow.day_index)) ||
-             (vehicle.sequence_timewindows.any?{ |tw| tw.day_index.nil? || current_day % 7 == tw.day_index }))
+        if !vehicle.unavailable_work_day_indices.include?(current_day) &&
+           (vehicle.timewindow.nil? && vehicle.sequence_timewindows.empty? ||
+           (vehicle.timewindow && (vehicle.timewindow.day_index.nil? || current_day % 7 == vehicle.timewindow.day_index)) ||
+           (vehicle.sequence_timewindows.any?{ |tw| tw.day_index.nil? || current_day % 7 == tw.day_index }))
           decimal_day += (service.minimum_lapse || 1)
           current_day = decimal_day.round
           current_visit += 1

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3007,6 +3007,22 @@ class WrapperTest < Minitest::Test
     assert_equal(2, result.count{ |un| un[:reason] == 'Unconsistency between visit number and minimum lapse' })
   end
 
+  def test_impossible_lapse_advanced
+    vrp = VRP.scheduling
+    vrp[:services].first[:visits_number] = 2
+    vrp[:services].first[:minimum_lapse] = 1
+    vrp[:vehicles].first[:timewindow][:day_index] = 0
+    vrp[:vehicles] << {
+      id: 'fake vehicle',
+      timewindow: { day_index: 1 }
+    }
+    vrp[:configuration][:preprocessing][:partitions] = TestHelper.vehicle_and_days_partitions
+
+    # we split by work_day, each vehicle will only drive one day in the schedule so it is not possible to affect service with two visits
+    assert_equal 2, OptimizerWrapper.config[:services][:ortools].detect_unfeasible_services(TestHelper.create(vrp)).size
+    assert_equal 1, OptimizerWrapper.config[:services][:ortools].detect_unfeasible_services(TestHelper.create(vrp)).uniq{ |un| un[:original_service_id] }.size
+  end
+
   def test_impossible_minimum_lapse_opened_days_real_case
     vrp = TestHelper.load_vrp(self, fixture_file: 'real_case_impossible_visits_because_lapse')
     result = OptimizerWrapper.config[:services][:demo].detect_unfeasible_services(vrp)


### PR DESCRIPTION
For each visit day we used to check there was one available vehicle, but in fact we want one vehicle to be available for each visit day.