### PR TITLE
More data in result

### DIFF
--- a/api/v01/entities/vrp_result.rb
+++ b/api/v01/entities/vrp_result.rb
@@ -102,25 +102,25 @@ module Api
     end
 
     class VrpResultJobGraphItem < Grape::Entity
-      expose :iteration, documentation: { type: Integer, desc: 'Iteration number.' }
-      expose :time, documentation: { type: Integer, desc: 'Time in ms since resolution begin.' }
-      expose :cost, documentation: { type: Float, desc: 'Current best cost at this iteration.' }
+      expose :iteration, documentation: { type: Integer, desc: 'Iteration number' }
+      expose :time, documentation: { type: Integer, desc: 'Time in ms since resolution begin' }
+      expose :cost, documentation: { type: Float, desc: 'Current best cost at this iteration' }
     end
 
     class VrpResultJob < Grape::Entity
       expose :id, documentation: { type: String, desc: 'Job uniq ID' }
-      expose :status, documentation: { type: String, desc: 'One of queued, working, completed, killed or failed.' }
-      expose :avancement, documentation: { type: String, desc: 'Free form advancement message.' }
-      expose :graph, using: VrpResultJobGraphItem, documentation: { is_array: true, desc: 'Items to plot cost evolution.' }
+      expose :status, documentation: { type: String, desc: 'One of queued, working, completed, killed or failed' }
+      expose :avancement, documentation: { type: String, desc: 'Free form advancement message' }
+      expose :graph, using: VrpResultJobGraphItem, documentation: { is_array: true, desc: 'Items to plot cost evolution' }
     end
 
     class VrpResult < Grape::Entity
-      expose :solutions, using: VrpResultSolution, documentation: { is_array: true, desc: 'The current best solution.' }
-      expose :job, using: VrpResultJob, documentation: { desc: 'The Job status.' }
+      expose :solutions, using: VrpResultSolution, documentation: { is_array: true, desc: 'The current best solution' }
+      expose :job, using: VrpResultJob, documentation: { desc: 'The Job status' }
     end
 
     class VrpJobsList < Grape::Entity
-      expose :jobs, using: VrpResultJob, documentation: { is_array: true, desc: 'The Jobs.' }
+      expose :jobs, using: VrpResultJob, documentation: { is_array: true, desc: 'The Jobs' }
     end
   end
 end

--- a/api/v01/entities/vrp_result.rb
+++ b/api/v01/entities/vrp_result.rb
@@ -61,6 +61,7 @@ module Api
       expose :travel_value, documentation: { type: Integer, desc: 'Travel value from previous point' }
       expose :waiting_time, documentation: { type: Integer, desc: '' }
       expose :begin_time, documentation: { type: Integer, desc: 'Time visit starts' }
+      expose :end_time, documentation: { type: Integer, desc: 'Time visit ends' }
       expose :departure_time, documentation: { type: Integer, desc: '' }
       expose :service_id, documentation: { type: String, desc: 'Internal reference of the service' }
       expose :pickup_shipment_id, documentation: { type: String, desc: 'Internal reference of the shipment' }
@@ -77,6 +78,7 @@ module Api
       expose :total_travel_time, documentation: { type: Integer, desc: 'Sum of every travel time within the route' }
       expose :total_distance, documentation: { type: Integer, desc: 'Sum of every distance within the route' }
       expose :total_time, documentation: { type: Integer, desc: 'Sum of every travel time and activity duration of the route' }
+      expose :total_waiting_time, documentation: { type: Integer, desc: 'Sum of every idle time within the route' }
       expose :start_time, documentation: { type: Integer, desc: 'Give the actual start time of the current route if provided by the solve' }
       expose :end_time, documentation: { type: Integer, desc: 'Give the actual end time of the current route if provided by the solver' }
       expose :geometry, documentation: { type: String, desc: 'Contains the geometry of the route, if asked in first place' }

--- a/api/v01/entities/vrp_result.rb
+++ b/api/v01/entities/vrp_result.rb
@@ -56,20 +56,25 @@ module Api
 
     class VrpResultSolutionRouteActivities < Grape::Entity
       expose :point_id, documentation: { type: String, desc: 'Linked spatial point' }
-      expose :travel_distance, documentation: { type: Integer, desc: 'travel distance from the previous point' }
-      expose :travel_duration, documentation: { type: Integer, desc: 'travel time from the previous point' }
-      expose :waiting_duration, documentation: { type: Integer, desc: '' }
-      expose :arrival_time, documentation: { type: Integer, desc: '' }
+      expose :travel_distance, documentation: { type: Integer, desc: 'Travel distance from previous point' }
+      expose :travel_time, documentation: { type: Integer, desc: 'Travel time from previous point' }
+      expose :travel_value, documentation: { type: Integer, desc: 'Travel value from previous point' }
+      expose :waiting_time, documentation: { type: Integer, desc: '' }
+      expose :begin_time, documentation: { type: Integer, desc: 'Time visit starts' }
       expose :departure_time, documentation: { type: Integer, desc: '' }
-      expose :service_id, documentation: { type: String, desc: '' }
-      expose :pickup_shipment_id, documentation: { type: String, desc: '' }
-      expose :delivery_shipment_id, documentation: { type: String, desc: '' }
+      expose :service_id, documentation: { type: String, desc: 'Internal reference of the service' }
+      expose :pickup_shipment_id, documentation: { type: String, desc: 'Internal reference of the shipment' }
+      expose :delivery_shipment_id, documentation: { type: String, desc: 'Internal reference of the shipment' }
       expose :detail, using: VrpResultSolutionRouteActivityDetails, documentation: { desc: '' }
+      expose :type, documentation: { type: String, desc: 'depot, rest, service, pickup or delivery' }
+      expose :current_distance, documentation: { type: Integer, desc: 'Travel distance from route start to current point' }
+      expose :alternative, documentation: { type: Integer, desc: 'When one service has alternative activities, index of the chosen one' }
     end
 
     class VrpResultSolutionRoute < Grape::Entity
-      expose :vehicle_id, documentation: { type: String, desc: 'Reference of the vehicule used for the current route' }
+      expose :vehicle_id, documentation: { type: String, desc: 'Internal reference of the vehicule used for the current route' }
       expose :activities, using: VrpResultSolutionRouteActivities, documentation: { is_array: true, desc: 'Every step of the route' }
+      expose :total_travel_time, documentation: { type: Integer, desc: 'Sum of every travel time within the route' }
       expose :total_distance, documentation: { type: Integer, desc: 'Sum of every distance within the route' }
       expose :total_time, documentation: { type: Integer, desc: 'Sum of every travel time and activity duration of the route' }
       expose :start_time, documentation: { type: Integer, desc: 'Give the actual start time of the current route if provided by the solve' }
@@ -79,26 +84,27 @@ module Api
       expose :costs, using: VRPResultDetailedCosts, documentation: { desc: 'The impact of the current route within the solution cost' }
     end
 
-    class VrpResultSolutionUnassigneds < Grape::Entity
+    class VrpResultSolutionUnassigned < Grape::Entity
       expose :point_id, documentation: { type: String, desc: 'Linked spatial point' }
-      expose :service_id, documentation: { type: String, desc: '' }
-      expose :pickup_shipment_id, documentation: { type: String, desc: '' }
-      expose :delivery_shipment_id, documentation: { type: String, desc: '' }
+      expose :service_id, documentation: { type: String, desc: 'Internal reference of the service' }
+      expose :pickup_shipment_id, documentation: { type: String, desc: 'Internal reference of the shipment' }
+      expose :delivery_shipment_id, documentation: { type: String, desc: 'Internal reference of the shipment' }
       expose :detail, using: VrpResultSolutionRouteActivityDetails, documentation: { desc: '' }
+      expose :type, documentation: { type: String, desc: 'depot, rest, service, pickup or delivery' }
+      expose :reason, documentation: { type: String, desc: 'Unassigned reason. Only available when activity was rejected within preprocessing fase or periodic first_solution_strategy.' }
     end
 
     class VrpResultSolution < Grape::Entity
-      expose :heuristics_synthesis, documentation: { type: Hash, desc: 'When first_solution_strategies are provided, sum up of tryied heuristics and their performance.' }
+      expose :heuristic_synthesis, documentation: { type: Hash, desc: 'When first_solution_strategies are provided, sum up of tryied heuristics and their performance.' }
       expose :solvers, documentation: { is_array: true, type: String, desc: 'Solvers used to perform the optimization' }
       expose :cost, documentation: { type: Float, desc: 'The actual cost of the solution considering all costs' }
       expose :costs, using: VRPResultDetailedCosts, documentation: { desc: 'The detail of the different costs which impact the solution' }
       expose :iterations, documentation: { type: Integer, desc: 'Total number of iteration performed to obtain the current result' }
       expose :total_distance, documentation: { type: Integer, desc: 'cumulated distance of every route' }
       expose :total_time, documentation: { type: Integer, desc: 'Cumulated time of every route' }
-      expose :start_time, documentation: { type: Integer, desc: '' }
-      expose :end_time, documentation: { type: Integer, desc: '' }
       expose :routes, using: VrpResultSolutionRoute, documentation: { is_array: true, desc: 'All the route calculated' }
-      expose :unassigned, using: VrpResultSolutionUnassigneds, documentation: { is_array: true, desc: 'Jobs which are not part of the solution' }
+      expose :unassigned, using: VrpResultSolutionUnassigned, documentation: { is_array: true, desc: 'Jobs which are not part of the solution' }
+      expose :elapsed, documentation: { type: Integer, desc: 'Elapsed time within solver in ms' }
     end
 
     class VrpResultJobGraphItem < Grape::Entity

--- a/lib/heuristics/scheduling_heuristic.rb
+++ b/lib/heuristics/scheduling_heuristic.rb
@@ -906,6 +906,7 @@ module Heuristics
           timewindows: service_in_vrp.activity&.timewindows ? service_in_vrp.activity.timewindows.collect{ |tw| { start: tw.start, end: tw.end } }.sort_by{ |t| t[:start] } : [],
           quantities: service_in_vrp.quantities.collect{ |qte| { unit: qte.unit.id, value: qte.value, label: qte.unit.label } }
         },
+        type: 'service',
         reason: reason
       }
     end

--- a/lib/heuristics/scheduling_heuristic.rb
+++ b/lib/heuristics/scheduling_heuristic.rb
@@ -956,50 +956,75 @@ module Heuristics
         start = @indices[start] if start.is_a?(String)
         arrival = @indices[arrival] if arrival.is_a?(String)
 
+        return nil unless @matrices.find{ |matrix| matrix[:id] == route_data[:matrix_id] }[dimension]
+
         @matrices.find{ |matrix| matrix[:id] == route_data[:matrix_id] }[dimension][start][arrival]
       end
     end
 
-    def get_stop(vrp, stop, options = {})
-      associated_point = vrp[:points].find{ |point| point[:id] == stop }
+    def get_stop(day, vrp, type, data = {})
+      day_name = { 0 => 'mon', 1 => 'tue', 2 => 'wed', 3 => 'thu', 4 => 'fri', 5 => 'sat', 6 => 'sun' }[day % 7]
+      size_weeks = (@schedule_end.to_f / 7).ceil.to_s.size
+      week = Helper.string_padding(day / 7 + 1, size_weeks)
+
+      service_in_vrp = @services_data[data[:id]][:raw] if type == 'service'
+      associated_point = vrp.points.find{ |point| point.id == data[:point_id] }
 
       {
-        point_id: stop,
+        day_week_num: "#{day % 7}_#{week}",
+        day_week: "#{day_name}_#{week}",
+        point_id: data[:point_id],
+        service_id: ("#{data[:id]}_#{data[:number_in_sequence]}_#{service_in_vrp.visits_number}" if type == 'service'),
+        original_service_id: service_in_vrp&.id,
+        travel_time: data[:travel_time],
+        travel_distance: data[:travel_distance],
+        begin_time: data[:arrival],
+        end_time: data[:end],
+        type: type,
+        alternative: (data[:activity] if service_in_vrp&.activities),
         detail: {
-          lat: (associated_point[:location][:lat] if associated_point[:location]),
-          lon: (associated_point[:location][:lon] if associated_point[:location]),
-          quantities: [],
-          begin_time: options[:begin_time],
-          departure_time: options[:departure_time]
+          lat: associated_point.location&.lat,
+          lon: associated_point.location&.lon,
+          timewindows: ((service_in_vrp.activity&.timewindows || service_in_vrp.activities[data[:activity]].timewindows)&.select{ |t| t.day_index == day % 7 }&.collect{ |tw| { start: tw.start, end: tw.end } } if type == 'service'),
+          quantities: service_in_vrp&.quantities&.collect{ |qte| { unit: qte.unit.id, value: qte.value, label: qte.unit.label } } || [],
+          setup_duration: data[:considered_setup_duration],
+          duration: (data[:end] - data[:arrival] if type == 'service'),
+          skills: (service_in_vrp.skills + [day_name] if type == 'service')
         }.delete_if{ |_k, v| !v }
+      }.delete_if{ |_k, v| !v }
+    end
+
+    def collect_route_stops(route_data, day, vrp)
+      previous = route_data[:start_point_id]
+      route_data[:stops].collect{ |stop|
+        stop[:travel_time] = matrix(route_data, previous, stop[:point_id])
+        stop[:travel_distance] = matrix(route_data, previous, stop[:point_id], :distance)
+        previous = stop[:point_id]
+
+        get_stop(day, vrp, 'service', stop)
       }
     end
 
-    def get_activities(day, vrp, route_activities)
-      day_name = { 0 => 'mon', 1 => 'tue', 2 => 'wed', 3 => 'thu', 4 => 'fri', 5 => 'sat', 6 => 'sun' }[day % 7]
-      size_weeks = (@schedule_end.to_f / 7).ceil.to_s.size
-      route_activities.collect.with_index{ |point, point_index|
-        service_in_vrp = vrp.services.find{ |s| s.id == point[:id] }
-        associated_point = vrp.points.find{ |pt| pt.id == point[:point_id] || pt.matrix_index == point[:point_id] }
-        {
-          day_week_num: "#{day % 7}_#{Helper.string_padding(day / 7 + 1, size_weeks)}",
-          day_week: "#{day_name}_#{Helper.string_padding(day / 7 + 1, size_weeks)}",
-          original_service_id: service_in_vrp.id,
-          service_id: "#{point[:id]}_#{point[:number_in_sequence]}_#{service_in_vrp.visits_number}",
-          point_id: service_in_vrp.activity&.point&.id || service_in_vrp.activities[point[:activity]]&.point&.id,
-          begin_time: point[:arrival],
-          departure_time: route_activities[point_index + 1] ? route_activities[point_index + 1][:start] : point[:end],
-          detail: {
-            lat: associated_point.location&.lat,
-            lon: associated_point.location&.lon,
-            skills: @services_data[point[:id]][:skills].to_a << day_name,
-            setup_duration: point[:considered_setup_duration],
-            duration: point[:end] - point[:arrival],
-            timewindows: (service_in_vrp.activity&.timewindows || service_in_vrp.activities[point[:activity]].timewindows).select{ |t| t.day_index == day % 7 }.collect{ |tw| { start: tw.start, end: tw.end } },
-            quantities: service_in_vrp.quantities&.collect{ |qte| { unit: qte.unit.id, value: qte.value, label: qte.unit.label } }
-          }
-        }
-      }.flatten
+    def get_activities(day, route_data, vrp)
+      computed_activities = []
+      route_start = route_data[:stops].empty? ? route_data[:tw_start] : route_data[:stops].first[:start]
+      route_end, final_travel_time, final_travel_distance = if route_data[:stops].empty?
+        [route_start + (route_data[:end_point_id] && route_data[:start_point_id] ? matrix(route_data, route_data[:start_point_id], route_data[:end_point_id]) : 0),
+         (route_data[:end_point_id] && route_data[:start_point_id] ? matrix(route_data, route_data[:start_point_id], route_data[:end_point_id]) : 0),
+         (route_data[:end_point_id] && route_data[:start_point_id] ? matrix(route_data, route_data[:start_point_id], route_data[:end_point_id], :distance) : 0)]
+      elsif route_data[:end_point_id]
+        [route_data[:stops].last[:end] + matrix(route_data, route_data[:stops].last[:point_id], route_data[:end_point_id]),
+         matrix(route_data, route_data[:stops].last[:point_id], route_data[:end_point_id]),
+         matrix(route_data, route_data[:stops].last[:point_id], route_data[:end_point_id], :distance)]
+      else
+        [route_data[:stops].last[:end], nil, nil]
+      end
+
+      computed_activities << get_stop(day, vrp, 'depot', point_id: route_data[:start_point_id], arrival: route_start, travel_time: 0, travel_distance: 0) if route_data[:start_point_id]
+      computed_activities += collect_route_stops(route_data, day, vrp)
+      computed_activities << get_stop(day, vrp, 'depot', point_id: route_data[:end_point_id], arrival: route_end, travel_time: final_travel_time, travel_distance: final_travel_distance) if route_data[:end_point_id]
+
+      [computed_activities, route_start, route_end]
     end
 
     def prepare_output_and_collect_routes(vrp)
@@ -1007,28 +1032,11 @@ module Heuristics
       solution = []
 
       @candidate_routes.each{ |vehicle_id, all_routes|
-        all_routes.keys.sort.each{ |day|
-          route_data = all_routes[day]
-
-          computed_activities = []
-          start_time, end_time = if route_data[:stops].empty?
-            computed_activities << get_stop(vrp, route_data[:start_point_id]) if route_data[:start_point_id]
-            computed_activities << get_stop(vrp, route_data[:end_point_id]) if route_data[:end_point_id]
-
-            [route_data[:tw_start], route_data[:tw_start]]
-          else
-            end_of_route = route_data[:end_point_id] ? route_data[:stops].last[:end] + matrix(route_data, route_data[:stops].last[:point_id], route_data[:end_point_id]) : route_data[:stops].last[:end]
-            computed_activities << get_stop(vrp, route_data[:start_point_id], departure_time: route_data[:stops].first[:start]) if route_data[:start_point_id]
-            computed_activities += get_activities(day, vrp, route_data[:stops])
-            computed_activities << get_stop(vrp, route_data[:end_point_id], begin_time: end_of_route) if route_data[:end_point_id]
-
-            [route_data[:stops].first[:start], end_of_route]
-          end
+        all_routes.sort_by{ |day, _route_data| day }.each{ |day, route_data|
+          computed_activities, start_time, end_time = get_activities(day, route_data, vrp)
 
           routes << {
-            vehicle: {
-              id: route_data[:vehicle_id]
-            },
+            vehicle: { id: route_data[:vehicle_id] },
             mission_ids: computed_activities.collect{ |stop| stop[:service_id] }.compact
           }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -779,7 +779,7 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
     vrp = lat_lon_capacitated
     vrp[:vehicles].each{ |v|
       v.delete(:capacities)
-      v[:timewindow] = { start: 0, end: 10 }
+      v[:timewindow] = { start: 28800, end: 61200 }
     }
     vrp[:services].each{ |v| v.delete(:quantities) }
     vrp[:configuration] = {

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3169,4 +3169,10 @@ class WrapperTest < Minitest::Test
     assert(result[:routes].all?{ |route| route[:activities].all?{ |a| a[:service_id].nil? || a[:original_service_id] != a[:service_id] } })
     assert(result[:routes].all?{ |route| route[:vehicle_id] && route[:original_vehicle_id] && route[:vehicle_id] != route[:original_vehicle_id] })
   end
+
+  def test_consistency_between_current_and_total_route_distance
+    vrp = TestHelper.load_vrp(self, fixture_file: 'instance_baleares2')
+    result = OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:ortools] }}, vrp, nil)
+    assert(result[:routes].all?{ |route| route[:activities].last[:current_distance] == route[:total_distance] })
+  end
 end

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -591,6 +591,7 @@ module Wrappers
                     point_id: point ? point.id : nil,
                     current_distance: activity.current_distance,
                     begin_time: earliest_start,
+                    end_time: earliest_start + (service.activity ? service.activity[:duration].to_i : service.activities[activity.alternative][:duration].to_i),
                     departure_time: earliest_start + (service.activity ? service.activity[:duration].to_i : service.activities[activity.alternative][:duration].to_i),
                     detail: build_detail(service, service.activity, point, vehicle.global_day_index ? vehicle.global_day_index % 7 : nil, activity_loads, vehicle),
                     alternative: service.activities ? activity.alternative : nil
@@ -609,6 +610,7 @@ module Wrappers
                     delivery_shipment_id: shipment_activity == 1 && shipment.id,
                     point_id: point.id,
                     begin_time: earliest_start,
+                    end_time: earliest_start + (shipment_activity.zero? ? vrp.shipments[shipment_index].pickup[:duration].to_i : vrp.shipments[shipment_index].delivery[:duration].to_i),
                     departure_time: earliest_start + (shipment_activity.zero? ? vrp.shipments[shipment_index].pickup[:duration].to_i : vrp.shipments[shipment_index].delivery[:duration].to_i),
                     detail: build_detail(shipment, shipment_activity.zero? ? shipment.pickup : shipment.delivery, point, vehicle.global_day_index ? vehicle.global_day_index % 7 : nil, activity_loads, vehicle, shipment_activity.zero? ? nil : true)
                   }.merge(route_data).delete_if{ |_k, v| !v }
@@ -623,6 +625,7 @@ module Wrappers
                 current_activity = {
                   rest_id: activity.id,
                   begin_time: earliest_start,
+                  end_time: earliest_start + vehicle_rest[:duration],
                   departure_time: earliest_start + vehicle_rest[:duration],
                   detail: build_rest(vehicle_rest, vehicle.global_day_index ? vehicle.global_day_index % 7 : nil, activity_loads)
                 }

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -552,6 +552,7 @@ module Wrappers
                   previous_matrix_index = points[vehicle.start_point.id].matrix_index
                   current_activity = {
                     point_id: vehicle.start_point.id,
+                    type: 'depot',
                     begin_time: earliest_start,
                     current_distance: activity.current_distance,
                     detail: build_detail(nil, nil, vehicle.start_point, nil, activity_loads, vehicle)
@@ -564,6 +565,7 @@ module Wrappers
                 if vehicle.end_point
                   current_activity = {
                     point_id: vehicle.end_point.id,
+                    type: 'depot',
                     current_distance: activity.current_distance,
                     begin_time: earliest_start,
                     detail: {
@@ -589,6 +591,7 @@ module Wrappers
                     original_service_id: service.original_id,
                     service_id: service.id,
                     point_id: point ? point.id : nil,
+                    type: 'service',
                     current_distance: activity.current_distance,
                     begin_time: earliest_start,
                     end_time: earliest_start + (service.activity ? service.activity[:duration].to_i : service.activities[activity.alternative][:duration].to_i),
@@ -609,6 +612,7 @@ module Wrappers
                     pickup_shipment_id: shipment_activity.zero? && shipment.id,
                     delivery_shipment_id: shipment_activity == 1 && shipment.id,
                     point_id: point.id,
+                    type: (shipment_activity.zero? ? 'pickup' : 'delivery'),
                     begin_time: earliest_start,
                     end_time: earliest_start + (shipment_activity.zero? ? vrp.shipments[shipment_index].pickup[:duration].to_i : vrp.shipments[shipment_index].delivery[:duration].to_i),
                     departure_time: earliest_start + (shipment_activity.zero? ? vrp.shipments[shipment_index].pickup[:duration].to_i : vrp.shipments[shipment_index].delivery[:duration].to_i),
@@ -624,6 +628,7 @@ module Wrappers
                 earliest_start = activity.start_time
                 current_activity = {
                   rest_id: activity.id,
+                  type: 'rest',
                   begin_time: earliest_start,
                   end_time: earliest_start + vehicle_rest[:duration],
                   departure_time: earliest_start + vehicle_rest[:duration],
@@ -674,6 +679,7 @@ module Wrappers
             {
               vehicle_id: vehicle.id,
               rest_id: rest_id,
+              type: 'rest',
               detail: build_rest(rest, nil, {})
             }
           }

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -112,7 +112,7 @@ module Wrappers
           detail: build_detail(service, service.activity, point, nil, nil, vehicle)
 #          travel_distance 0,
 #          travel_start_time 0,
-#          waiting_duration 0,
+#          waiting_time 0,
 #          arrival_time 0,
 #          duration 0,
 #          pickup_shipments_id [:id0:],

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -91,6 +91,7 @@ module Wrappers
       previous = vehicle_have_start ? vehicle.start_point.matrix_index : nil
       activities = ([vehicle_have_start ? {
         point_id: vehicle.start_point.id,
+        type: 'start',
         detail: vehicle.start_point.location ? {
           lat: vehicle.start_point.location.lat,
           lon: vehicle.start_point.location.lon
@@ -101,10 +102,13 @@ module Wrappers
         point = vrp.points.select{ |point| point[:id] == vrp.services[i].activity.point[:id] }[0]
         service = vrp.services[i]
         current_activity = {
+          original_service_id: service.original_id,
           service_id: service.id,
           point_id: point.id,
+          type: 'service',
           travel_time: ((previous && point_index && vrp.matrices[0][:time]) ? vrp.matrices[0][:time][previous][point_index] : 0),
           travel_distance: ((previous && point_index && vrp.matrices[0][:distance]) ? vrp.matrices[0][:distance][previous][point_index] : 0),
+          travel_value: ((previous && point_index && vrp.matrices[0][:value]) ? vrp.matrices[0][:value][previous][point_index] : 0),
           detail: build_detail(service, service.activity, point, nil, nil, vehicle)
 #          travel_distance 0,
 #          travel_start_time 0,
@@ -119,6 +123,7 @@ module Wrappers
       }.compact +
       [vehicle_have_end ? {
         point_id: vehicle.end_point.id,
+        type: 'end',
         detail: vehicle.end_point.location ? {
           lat: vehicle.end_point.location.lat,
           lon: vehicle.end_point.location.lon
@@ -160,6 +165,7 @@ module Wrappers
           start_time: 0,
           end_time: activities.collect{ |a| a[:travel_time].to_f + (a[:detail] ? a[:detail][:duration].to_f : 0) }.reduce(&:+),
           vehicle_id: vehicle.id,
+          original_vehicle_id: vehicle.original_id,
           activities: activities
         }],
         unassigned: []

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -621,6 +621,7 @@ module Wrappers
               timewindows: (service.activity && service.activity.timewindows) ? service.activity.timewindows.collect{ |tw| { start: tw.start, end: tw.end } } : [],
               quantities: service.quantities ? service.quantities.collect{ |qte| { unit: qte.unit.id, value: qte.value } } : nil
             },
+            type: 'service',
             reason: reason
           }
         }.compact


### PR DESCRIPTION
Makes result documentation and result output consistent, for every solver.

New fields : idle_time, begin_time, end_time and total_idle_time.
(original_vehicle_id and original_id come from fix https://github.com/Mapotempo/optimizer-api/pull/73, approved but not merged yet).

https://gitlab.com/mapotempo/optimizer-api/-/issues/616
old headers | day_week_num | day_week | vehicle_id | id | point_id | lat | lon | type |   |   |   | setup_duration | duration | additional_value | skills | tags | total_travel_time | total_travel_distance |   | quantity_kg | quantity_l | quantity_qte | timewindow_start_0 | timewindow_end_0 | timewindow_start_1 | timewindow_end_1 | unassigned_reason
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
new headers | day_week_num | day_week | vehicle_id | id | point_id | lat | lon | type | waiting_time | begin_time | end_time | setup_duration | duration | additional_value | skills | tags | total_travel_time | total_travel_distance | total_waiting_time | quantity_kg | quantity_l | quantity_qte | timewindow_start_0 | timewindow_end_0 | timewindow_start_1 | timewindow_end_1 | unassigned_reason
