### PR TITLE
Fix parse_output protobuf error + other small fixes

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -141,9 +141,9 @@ module Enumerable
   def median(already_sorted = false)
     return nil if empty?
 
-    sort! unless already_sorted
+    ret = already_sorted ? self : sort
     m_pos = size / 2 # no to_f!
-    size.odd? ? self[m_pos] : self[m_pos - 1..m_pos].mean
+    size.odd? ? ret[m_pos] : ret[m_pos - 1..m_pos].mean
   end
 
   # The mode is the single most popular item in the array.

--- a/test/real_cases_dichotomious_test.rb
+++ b/test/real_cases_dichotomious_test.rb
@@ -28,8 +28,8 @@ class RealCasesTest < Minitest::Test
       assert result
 
       # TODO: remove the logs after dicho overhead problem is fixed
-      log "duration_min = #{vrp[:configuration][:resolution][:minimum_duration] / 1000.to_f}", level: :debug
-      log "duration_max = #{vrp[:configuration][:resolution][:duration] / 1000.to_f}", level: :debug
+      log "duration_min = #{vrp.resolution_minimum_duration / 1000.to_f}", level: :debug
+      log "duration_max = #{vrp.resolution_duration / 1000.to_f}", level: :debug
       log "duration_optimization = #{result[:elapsed] / 1000.to_f}", level: :debug
       log "duration_elapsed =  #{t2 - t1}", level: :debug
 
@@ -37,8 +37,8 @@ class RealCasesTest < Minitest::Test
       assert result[:unassigned].size < 50, "Too many unassigned services #{result[:unassigned].size}"
 
       # Check time
-      duration_min = vrp[:configuration][:resolution][:minimum_duration] / 1000.to_f
-      duration_max = vrp[:configuration][:resolution][:duration] / 1000.to_f
+      duration_min = vrp.resolution_minimum_duration / 1000.to_f
+      duration_max = vrp.resolution_duration / 1000.to_f
       duration_optimization = result[:elapsed] / 1000.to_f
       duration_elapsed =  t2 - t1
 
@@ -61,8 +61,8 @@ class RealCasesTest < Minitest::Test
       assert result
 
       # TODO: remove the logs after dicho overhead problem is fixed
-      log "duration_min = #{vrp[:configuration][:resolution][:minimum_duration] / 1000.to_f}", level: :debug
-      log "duration_max = #{vrp[:configuration][:resolution][:duration] / 1000.to_f}", level: :debug
+      log "duration_min = #{vrp.resolution_minimum_duration / 1000.to_f}", level: :debug
+      log "duration_max = #{vrp.resolution_duration / 1000.to_f}", level: :debug
       log "duration_optimization = #{result[:elapsed] / 1000.to_f}", level: :debug
       log "duration_elapsed =  #{t2 - t1}", level: :debug
 
@@ -73,8 +73,8 @@ class RealCasesTest < Minitest::Test
       assert result[:routes].size < 48, "Too many routes: #{result[:routes].size}"
 
       # Check time
-      duration_min = vrp[:configuration][:resolution][:minimum_duration] / 1000.to_f
-      duration_max = vrp[:configuration][:resolution][:duration] / 1000.to_f
+      duration_min = vrp.resolution_minimum_duration / 1000.to_f
+      duration_max = vrp.resolution_duration / 1000.to_f
       duration_optimization = result[:elapsed] / 1000.to_f
       duration_elapsed =  t2 - t1
 

--- a/test/wrappers/ortools_test.rb
+++ b/test/wrappers/ortools_test.rb
@@ -4383,10 +4383,16 @@ class Wrappers::OrtoolsTest < Minitest::Test
           point_id: 'point_3'
         }
       }],
-      routes: [{
-        vehicle_id: 'vehicle_0',
-        mission_ids: ['service_1', 'service_3', 'service_2']
-      }],
+      routes: [
+        {
+          vehicle_id: 'vehicle_0',
+          mission_ids: ['service_2', 'service_3']
+        },
+        {
+          vehicle_id: 'vehicle_1',
+          mission_ids: ['service_1']
+        }
+      ],
       configuration: {
         resolution: {
           duration: 10

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -750,7 +750,7 @@ module Wrappers
         next unless r && t # if there is no iteration and time then there is nothing to do
 
         begin
-          @previous_result = if vrp.restitution_intermediate_solutions && s
+          @previous_result = if vrp.restitution_intermediate_solutions && s && !/Final Iteration :/.match(line)
                                parse_output(vrp, services, points, matrix_indices, cost, iterations, output)
                              end
           block&.call(self, iterations, nil, nil, cost, time, @previous_result) # if @previous_result=nil, it will not override the existing solution

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -480,6 +480,7 @@ module Wrappers
         return empty_result('ortools', vrp)
       end
 
+      output.rewind
       content = OrtoolsResult::Result.decode(output.read)
       output.rewind
 

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -684,11 +684,11 @@ module Wrappers
         return [0, 0, @previous_result = parse_output(vrp, services, points, matrix_indices, 0, 0, nil)]
       end
 
-      input = Tempfile.new('optimize-or-tools-input', @tmp_dir)
+      input = Tempfile.new('optimize-or-tools-input', @tmp_dir, binmode: true)
       input.write(OrtoolsVrp::Problem.encode(problem))
       input.close
 
-      output = Tempfile.new('optimize-or-tools-output', @tmp_dir)
+      output = Tempfile.new('optimize-or-tools-output', @tmp_dir, binmode: true)
 
       correspondant = { 'path_cheapest_arc' => 0, 'global_cheapest_arc' => 1, 'local_cheapest_insertion' => 2, 'savings' => 3, 'parallel_cheapest_insertion' => 4, 'first_unbound' => 5, 'christofides' => 6 }
 


### PR DESCRIPTION
Prevents parsing final solution twice
Rewinds the output before reading
Sets proto file mode to binary
Other small fixes in tests and a side-effect in median function