### PR TITLE
Bump to ruby 2.5 using passenger image

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.3.3
+  TargetRubyVersion: 2.5.5
 
 Layout/LineLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.3'
+ruby '~> 2.5.5'
 
 gem 'require_all'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ DEPENDENCIES
   thin
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.5.5p157
 
 BUNDLED WITH
    1.17.3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For ruby, bundler and gems, rbenv or rvm are recommanded.
 
 ### On Ubuntu
 
-* Ruby 2.3.3 (if not using rbenv/rvm)
+* Ruby 2.5.5 (if not using rbenv/rvm)
 ```
 sudo apt install ruby-full
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,30 +3,22 @@ ARG OPTIMIZER_ORTOOLS_VERSION=${OPTIMIZER_ORTOOLS_VERSION}
 ARG REGISTRY=${REGISTRY:-registry.mapotempo.com/}
 ARG VROOM_VERSION=${VROOM_VERSION}
 
-# Install Optimizer-ortools
-FROM ${REGISTRY}mapotempo-${BRANCH}/optimizer-ortools:${OPTIMIZER_ORTOOLS_VERSION} as optimizer-ortools
-
 # Install Vroom
-RUN echo ${REGISTRY}mapotempo/vroom:${VROOM_VERSION}
 FROM ${REGISTRY}mapotempo/vroom:${VROOM_VERSION} as vroom
 
-RUN echo ${VROOM_VERSION}
-
 # Rake
-FROM ruby:2.3.3 as rake
+FROM ${REGISTRY}mapotempo-${BRANCH}/optimizer-ortools:${OPTIMIZER_ORTOOLS_VERSION}
 
 ENV LANG C.UTF-8
 
-RUN apt-get update > /dev/null && \
-  apt-get install -y git build-essential libgeos-dev libgeos-3.4.2 libicu-dev zlib1g-dev zlib1g nano > /dev/null
+RUN apt-get update > /dev/null
+RUN libgeos=$(apt-cache search 'libgeos-' | grep -P 'libgeos-\d.*' | awk '{print $1}')
+RUN apt-get install -y git libgeos-dev ${libgeos} libicu-dev nano > /dev/null
 
 COPY . /srv/app
 WORKDIR /srv/app
-RUN gem install bundler --version 1.17.3
 RUN bundle --version
 RUN bundle check || bundle install --full-index --without development -j $(nproc)
-# Final image
-FROM ruby:2.3.3
 
 LABEL maintainer="Mapotempo <contact@mapotempo.com>"
 
@@ -34,18 +26,14 @@ ENV APP_ENV production
 ENV REDIS_HOST redis-cache
 ENV LANG C.UTF-8
 
-COPY --from=optimizer-ortools /srv/or-tools srv/or-tools
-COPY --from=optimizer-ortools /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/
-COPY --from=optimizer-ortools /srv/optimizer-ortools /srv/optimizer-ortools
-COPY --from=optimizer-ortools /lib/x86_64-linux-gnu/libm* /lib/x86_64-linux-gnu/
 COPY --from=vroom /srv/vroom/bin /srv/vroom/bin
 COPY --from=vroom /usr/lib/x86_64-linux-gnu/libboost* /usr/lib/x86_64-linux-gnu/
-COPY --from=rake /srv/app /srv/app
-COPY --from=rake /usr/local/bundle /usr/local/bundle
-COPY --from=rake /usr/local/ /usr/local/
-COPY --from=rake /usr/lib/libgeos* /usr/lib/
-COPY --from=rake /usr/lib/x86_64-linux-gnu/icu* /usr/lib/x86_64-linux-gnu/
-COPY --from=rake /usr/lib/x86_64-linux-gnu/libicu* /usr/lib/x86_64-linux-gnu/
+
+RUN apt-get remove -y git build-essential && \
+  apt-get autoremove -y && \
+  apt-get clean && \
+  echo -n > /var/lib/apt/extended_states && \
+  rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 WORKDIR /srv/app
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,23 @@
 version: '3.3'
 services:
+  redis:
+    image: redis:${REDIS_VERSION:-3.2-alpine}
+    hostname: travis-redis
+    volumes:
+      - ../redis:/data
+    command: redis-server --appendonly yes
+    networks:
+      - resque
+
+  redis-cache:
+    image: redis:${REDIS_VERSION:-3.2-alpine}
+    hostname: travis-redis-cache
+    volumes:
+      - ../redis:/data
+    command: redis-server --save ""
+    networks:
+      - redis_cache
+
   api:
     image: registry.test.com/mapotempo/optimizer-api:latest
     hostname: travis-api
@@ -28,24 +46,6 @@ services:
     networks:
       - redis_cache
       - resque
-
-  redis:
-    image: redis:${REDIS_VERSION:-3.2-alpine}
-    hostname: travis-redis
-    volumes:
-      - ../redis:/data
-    command: redis-server --appendonly yes
-    networks:
-      - resque
-
-  redis-cache:
-    image: redis:${REDIS_VERSION:-3.2-alpine}
-    hostname: travis-redis-cache
-    volumes:
-      - ../redis:/data
-    command: redis-server --save ""
-    networks:
-      - redis_cache
 
 networks:
   resque:

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -603,7 +603,7 @@ class SplitClusteringTest < Minitest::Test
         unassigned_service_ids = result[:unassigned].collect{ |unassigned| unassigned[:original_service_id] }
         unassigned_service_ids.uniq!
         services_unassigned << unassigned_service_ids.size
-        reason_unassigned << result[:unassigned].map{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.map{ |k, v| [k, v.length] }.to_h
+        reason_unassigned << result[:unassigned].transform_values{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.map{ |k, v| [k, v.length] }
       }
 
       if services_unassigned.max - services_unassigned.min.to_f >= 2 || visits_unassigned.max >= 5
@@ -646,7 +646,7 @@ class SplitClusteringTest < Minitest::Test
         unassigned_service_ids = result[:unassigned].collect{ |unassigned| unassigned[:original_service_id] }
         unassigned_service_ids.uniq!
         services_unassigned << unassigned_service_ids.size
-        reason_unassigned << result[:unassigned].map{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.map{ |k, v| [k, v.length] }.to_h
+        reason_unassigned << result[:unassigned].map{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.transform_values{ |k, v| [k, v.length] }
       }
 
       if services_unassigned.max - services_unassigned.min.to_f >= 10 || visits_unassigned.max >= 15


### PR DESCRIPTION
This PR makes Docker use passenger instead of rake. It fixes the warning message about some libs incompatibilities with optimizer-ortools images since this one is now based on.