### PR TITLE
[optim-ortools] fixes for maj

### DIFF
--- a/ci-utils/version.sh
+++ b/ci-utils/version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ $TRAVIS_BRANCH == "master" ]] || [[ $TRAVIS_TAG != "" ]]; then
-  export OPTIMIZER_ORTOOLS_VERSION="v1.3.0";
+  export OPTIMIZER_ORTOOLS_VERSION="v1.4.0";
 else
   export OPTIMIZER_ORTOOLS_VERSION=${OPTIMIZER_ORTOOLS_VERSION:-Mapotempo};
 fi

--- a/lib/heuristics/scheduling_heuristic.rb
+++ b/lib/heuristics/scheduling_heuristic.rb
@@ -980,6 +980,7 @@ module Heuristics
         travel_distance: data[:travel_distance],
         begin_time: data[:arrival],
         end_time: data[:end],
+        departure_time: data[:end],
         type: type,
         alternative: (data[:activity] if service_in_vrp&.activities),
         detail: {

--- a/test/api/v01/output_test.rb
+++ b/test/api/v01/output_test.rb
@@ -279,14 +279,14 @@ class Api::V01::OutputTest < Api::V01::RequestHelper
         problem: VRP.lat_lon_two_vehicles,
         solver_name: 'ortools',
         expected_route_keys: %w[vehicle_id original_vehicle_id activities total_travel_time total_distance total_time total_waiting_time start_time end_time costs initial_loads],
-        expected_activities_keys: %w[point_id travel_distance travel_time travel_value waiting_time begin_time end_time service_id original_service_id detail current_distance alternative type departure_time],
+        expected_activities_keys: %w[point_id travel_distance travel_time travel_value waiting_time begin_time end_time departure_time service_id original_service_id detail current_distance alternative type],
         expected_unassigned_keys: %w[point_id service_id original_service_id detail type reason]
       },
       periodic_heuristic: {
         problem: VRP.lat_lon_scheduling,
         solver_name: 'heuristic',
         expected_route_keys: %w[vehicle_id original_vehicle_id activities total_travel_time total_distance total_time total_waiting_time start_time end_time],
-        expected_activities_keys: %w[point_id travel_distance travel_time waiting_time begin_time end_time service_id original_service_id detail current_distance alternative type day_week_num day_week],
+        expected_activities_keys: %w[point_id travel_distance travel_time waiting_time begin_time end_time departure_time service_id original_service_id detail current_distance alternative type day_week_num day_week],
         expected_unassigned_keys: %w[point_id service_id original_service_id detail type reason]
       }
     }

--- a/test/lib/heuristics/scheduling_test.rb
+++ b/test/lib/heuristics/scheduling_test.rb
@@ -492,7 +492,7 @@ class HeuristicTest < Minitest::Test
       assert(candidate_routes.any?{ |_vehicle, vehicle_data| vehicle_data.any?{ |_day, data| data[:stops].size == expecting.size } })
 
       # providing uncomplete solution (compared to solution without initial routes)
-      puts "On vehicle ANDALUCIA 1_2, expecting #{expecting}"
+      OptimizerLogger.log "On vehicle ANDALUCIA 1_2, expecting #{expecting}"
       vrp = TestHelper.load_vrp(self, fixture_file: 'instance_andalucia1_two_vehicles')
       vrp.routes = routes
       result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, vrp, nil)
@@ -502,7 +502,7 @@ class HeuristicTest < Minitest::Test
 
       # providing different solution (compared to solution without initial routes)
       vehicle_id, day = vrp.routes.first.vehicle.id.split('_')
-      puts "On vehicle #{vehicle_id}_#{day}, expecting #{expecting}"
+      OptimizerLogger.log "On vehicle #{vehicle_id}_#{day}, expecting #{expecting}"
       vrp = TestHelper.load_vrp(self, fixture_file: 'instance_andalucia1_two_vehicles')
       vrp.routes = routes
       vrp.routes.first.vehicle.id = vehicle_id

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -603,7 +603,7 @@ class SplitClusteringTest < Minitest::Test
         unassigned_service_ids = result[:unassigned].collect{ |unassigned| unassigned[:original_service_id] }
         unassigned_service_ids.uniq!
         services_unassigned << unassigned_service_ids.size
-        reason_unassigned << result[:unassigned].transform_values{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.map{ |k, v| [k, v.length] }
+        reason_unassigned << result[:unassigned].map{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.transform_values(&:length)
       }
 
       if services_unassigned.max - services_unassigned.min.to_f >= 2 || visits_unassigned.max >= 5
@@ -646,7 +646,7 @@ class SplitClusteringTest < Minitest::Test
         unassigned_service_ids = result[:unassigned].collect{ |unassigned| unassigned[:original_service_id] }
         unassigned_service_ids.uniq!
         services_unassigned << unassigned_service_ids.size
-        reason_unassigned << result[:unassigned].map{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.transform_values{ |k, v| [k, v.length] }
+        reason_unassigned << result[:unassigned].map{ |unass| unass[:reason].slice(0, 8) }.group_by{ |e| e }.transform_values(&:length)
       }
 
       if services_unassigned.max - services_unassigned.min.to_f >= 10 || visits_unassigned.max >= 15

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -640,7 +640,7 @@ class SplitClusteringTest < Minitest::Test
       reason_unassigned = []
       vrp = Marshal.dump(TestHelper.load_vrp(self)) # call load_vrp only once to not to dump for each restart
       (1..@regularity_restarts).each{ |trial|
-        puts "Regularity trial: #{trial}/#{@regularity_restarts}"
+        OptimizerLogger.log "Regularity trial: #{trial}/#{@regularity_restarts}"
         result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, Marshal.load(vrp), nil) # rubocop: disable Security/MarshalLoad
         visits_unassigned << result[:unassigned].size
         unassigned_service_ids = result[:unassigned].collect{ |unassigned| unassigned[:original_service_id] }

--- a/test/real_cases_dichotomious_test.rb
+++ b/test/real_cases_dichotomious_test.rb
@@ -21,6 +21,9 @@ class RealCasesTest < Minitest::Test
   if !ENV['SKIP_REAL_DICHO'] && !ENV['SKIP_DICHO'] && !ENV['TRAVIS']
 
     def test_dichotomious_first_instance
+      skip "This test have incorrect bounds so it never passes and it takes 3 hours to complete.
+            Followed by gitlab-issue https://gitlab.com/mapotempo/optimizer-api/-/issues/648"
+
       vrp = TestHelper.load_vrp(self)
       t1 = Time.now
       result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, vrp, nil)
@@ -54,6 +57,9 @@ class RealCasesTest < Minitest::Test
     end
 
     def test_dichotomious_second_instance
+      skip "This test have incorrect bounds so it never passes and it takes 3 hours to complete.
+            Followed by gitlab-issue https://gitlab.com/mapotempo/optimizer-api/-/issues/648"
+
       vrp = TestHelper.load_vrp(self)
       t1 = Time.now
       result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, vrp, nil)

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -753,7 +753,7 @@ module Wrappers
         s && (cost = Float(s[1]))
         t = /Time : ([0-9.eE+]+)/.match(line)
         t && (time = t[1].to_f)
-        log line.strip, level: (/Final Iteration :/.match(line) || /First solution strategy :/.match(line) || /Using initial solution provided./.match(line) || /OR-Tools v[0-9]+\.[0-9]+\n/.match(line)) ? :info : (r || s || t) ? :debug : :error
+        log line.strip, level: (/Final Iteration :/.match(line) || /First solution strategy :/.match(line) || /Using the provided initial solution./.match(line) || /OR-Tools v[0-9]+\.[0-9]+\n/.match(line)) ? :info : (r || s || t) ? :debug : :error
         out += line
 
         next unless r && t # if there is no iteration and time then there is nothing to do

--- a/wrappers/ortools_vrp_pb.rb
+++ b/wrappers/ortools_vrp_pb.rb
@@ -15,7 +15,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   end
   add_message 'ortools_vrp.Service' do
     repeated :time_windows, :message, 1, 'ortools_vrp.TimeWindow'
-    repeated :quantities, :int64, 2
+    repeated :quantities, :float, 2
     optional :duration, :uint32, 3
     optional :priority, :uint32, 4
     repeated :vehicle_indices, :int32, 5
@@ -23,7 +23,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :setup_duration, :uint32, 7
     optional :id, :string, 9
     optional :late_multiplier, :float, 10
-    repeated :setup_quantities, :int32, 11
+    repeated :setup_quantities, :float, 11
     optional :additional_value, :uint32, 12
     optional :exclusion_cost, :int64, 13
     repeated :refill_quantities, :bool, 14
@@ -37,7 +37,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :exclusion_cost, :int64, 5
   end
   add_message 'ortools_vrp.Capacity' do
-    optional :limit, :int64, 1
+    optional :limit, :float, 1
     optional :overload_multiplier, :float, 2
     optional :counting, :bool, 3
   end


### PR DESCRIPTION
Needs https://github.com/Mapotempo/optimizer-ortools/pull/19 to be merged first

Remaining fixes for maj

- The cost error is corrected by moving the quantity multiplication logic to optim-ortools so that both final and intermediate costs will always be correct on optim-api side and inside ortools
- Other small fixes for tests