### PR TITLE
Provide & respect specified units in result

### DIFF
--- a/api/v01/entities/vrp_result.rb
+++ b/api/v01/entities/vrp_result.rb
@@ -59,10 +59,10 @@ module Api
       expose :day_week_num, expose_nil: false, documentation: { type: String, desc: '' }
       expose :day_week, expose_nil: false, documentation: { type: String, desc: '' }
       expose :point_id, documentation: { type: String, desc: 'Linked spatial point' }
-      expose :travel_distance, documentation: { type: Integer, desc: 'Travel distance from previous point' }
-      expose :travel_time, documentation: { type: Integer, desc: 'Travel time from previous point' }
+      expose :travel_distance, documentation: { type: Integer, desc: 'Travel distance from previous point (in m)' }
+      expose :travel_time, documentation: { type: Integer, desc: 'Travel time from previous point (in s)' }
       expose :travel_value, documentation: { type: Integer, desc: 'Travel value from previous point' }
-      expose :waiting_time, documentation: { type: Integer, desc: '' }
+      expose :waiting_time, documentation: { type: Integer, desc: 'Idle time (in s)' }
       expose :begin_time, documentation: { type: Integer, desc: 'Time visit starts' }
       expose :end_time, documentation: { type: Integer, desc: 'Time visit ends' }
       expose :departure_time, documentation: { type: Integer, desc: '' }
@@ -72,17 +72,17 @@ module Api
       expose :rest_id, expose_nil: false, documentation: { type: String, desc: 'Internal reference of the rest' }
       expose :detail, using: VrpResultSolutionRouteActivityDetails, documentation: { desc: '' }
       expose :type, documentation: { type: String, desc: 'depot, rest, service, pickup or delivery' }
-      expose :current_distance, documentation: { type: Integer, desc: 'Travel distance from route start to current point' }
+      expose :current_distance, documentation: { type: Integer, desc: 'Travel distance from route start to current point (in m)' }
       expose :alternative, documentation: { type: Integer, desc: 'When one service has alternative activities, index of the chosen one' }
     end
 
     class VrpResultSolutionRoute < Grape::Entity
       expose :vehicle_id, documentation: { type: String, desc: 'Internal reference of the vehicule used for the current route' }
       expose :activities, using: VrpResultSolutionRouteActivities, documentation: { is_array: true, desc: 'Every step of the route' }
-      expose :total_travel_time, documentation: { type: Integer, desc: 'Sum of every travel time within the route' }
-      expose :total_distance, documentation: { type: Integer, desc: 'Sum of every distance within the route' }
-      expose :total_time, documentation: { type: Integer, desc: 'Sum of every travel time and activity duration of the route' }
-      expose :total_waiting_time, documentation: { type: Integer, desc: 'Sum of every idle time within the route' }
+      expose :total_travel_time, documentation: { type: Integer, desc: 'Sum of every travel time within the route (in s)' }
+      expose :total_distance, documentation: { type: Integer, desc: 'Sum of every distance within the route (in m)' }
+      expose :total_time, documentation: { type: Integer, desc: 'Sum of every travel time and activity duration of the route (in s)' }
+      expose :total_waiting_time, documentation: { type: Integer, desc: 'Sum of every idle time within the route (in s)' }
       expose :start_time, documentation: { type: Integer, desc: 'Give the actual start time of the current route if provided by the solve' }
       expose :end_time, documentation: { type: Integer, desc: 'Give the actual end time of the current route if provided by the solver' }
       expose :geometry, documentation: { type: String, desc: 'Contains the geometry of the route, if asked in first place' }
@@ -107,10 +107,10 @@ module Api
       expose :cost, documentation: { type: Float, desc: 'The actual cost of the solution considering all costs' }
       expose :cost_details, using: VRPResultDetailedCosts, documentation: { desc: 'The detail of the different costs which impact the solution' }
       expose :iterations, documentation: { type: Integer, desc: 'Total number of iteration performed to obtain the current result' }
-      expose :total_distance, documentation: { type: Integer, desc: 'cumulated distance of every route' }
-      expose :total_time, documentation: { type: Integer, desc: 'Cumulated time of every route' }
-      expose :total_travel_time, documentation: { type: Integer, type: 'Cumulated travel time of every route'}
-      expose :total_waiting_time, documentation: { type: Integer, type: 'Cumulated idle time of every route' }
+      expose :total_distance, documentation: { type: Integer, desc: 'cumulated distance of every route (in m)' }
+      expose :total_time, documentation: { type: Integer, desc: 'Cumulated time of every route (in s)' }
+      expose :total_travel_time, documentation: { type: Integer, desc: 'Cumulated travel time of every route (in s)' }
+      expose :total_waiting_time, documentation: { type: Integer, desc: 'Cumulated idle time of every route (in s)' }
       expose :routes, using: VrpResultSolutionRoute, documentation: { is_array: true, desc: 'All the route calculated' }
       expose :unassigned, using: VrpResultSolutionUnassigned, documentation: { is_array: true, desc: 'Jobs which are not part of the solution' }
       expose :elapsed, documentation: { type: Integer, desc: 'Elapsed time within solver in ms' }

--- a/lib/interpreters/multi_modal.rb
+++ b/lib/interpreters/multi_modal.rb
@@ -288,7 +288,7 @@ module Interpreters
         subvrps = generate_subproblems(skills_patterns)
         subresults = solve_subproblems(subvrps)
         result = override_original_vrp(subresults)
-        rebuild_entire_route(subresults, result)
+        OptimizerWrapper.parse_result(@original_vrp, rebuild_entire_route(subresults, result))
       end
     end
   end

--- a/optimizer_wrapper.rb
+++ b/optimizer_wrapper.rb
@@ -653,13 +653,17 @@ module OptimizerWrapper
     end
   end
 
-  def self.compute_result_total_dimensions(result)
+  def self.compute_result_total_dimensions_and_round_route_stats(result)
     [:total_time, :total_travel_time, :total_travel_value, :total_distance, :total_waiting_time].each{ |stat_symbol|
       next unless result[:routes].all?{ |r| r[stat_symbol] }
 
       result[stat_symbol] = result[:routes].collect{ |r|
         r[stat_symbol]
       }.reduce(:+)
+    }
+
+    result[:routes].each{ |r|
+      round_route_stats(r)
     }
   end
 
@@ -800,10 +804,8 @@ module OptimizerWrapper
         details = route_details(vrp, r, v) if details.nil?
         r[:geometry] = details.map(&:last) if details
       end
-
-      round_route_stats(r)
     }
-    compute_result_total_dimensions(result)
+    compute_result_total_dimensions_and_round_route_stats(result)
 
     log "result - unassigned rate: #{result[:unassigned].size} of (ser: #{vrp.visits}, ship: #{vrp.shipments.size}) (#{(result[:unassigned].size.to_f / (vrp.visits + 2 * vrp.shipments.size) * 100).round(1)}%)"
     used_vehicle_count = result[:routes].count{ |r| r[:activities].any?{ |a| a[:service_id] || a[:pickup_shipment_id] } }

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -875,7 +875,7 @@ module Wrappers
 
     def empty_result(solver, vrp, unassigned_reason = nil, already_expanded = true)
       vrp.vehicles = expand_vehicles_for_consistent_empty_result(vrp) if vrp.scheduling? && !already_expanded
-      {
+      OptimizerWrapper.parse_result(vrp, {
         solvers: [solver],
         cost: nil,
         cost_details: Models::CostDetails.new({}),
@@ -886,7 +886,7 @@ module Wrappers
                      unassigned_rests(vrp)).flatten,
         elapsed: 0,
         total_distance: nil
-      }
+      })
     end
 
     def kill; end


### PR DESCRIPTION
One of our customers notices than, from scheduling heuristic, routes' _start_time_ and _end_time_ could be either integers or floatting numbers.