### PR TITLE
move tests unconsistent with api tests

### DIFF
--- a/test/lib/heuristics/scheduling_instance_validity_test.rb
+++ b/test/lib/heuristics/scheduling_instance_validity_test.rb
@@ -22,7 +22,7 @@ class InstanceValidityTest < Minitest::Test
     def test_reject_if_no_heuristic_neither_first_sol_strategy
       problem = VRP.scheduling
       problem[:configuration][:preprocessing][:first_solution_strategy] = []
-      problem[:configuration][:resolution][:solver_parameter] = -1
+      problem[:configuration][:resolution][:solver] = false
 
       assert_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(TestHelper.create(problem)), :assert_solver_if_not_periodic
     end
@@ -127,25 +127,6 @@ class InstanceValidityTest < Minitest::Test
       refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(TestHelper.create(problem)), :assert_route_date_or_indice_if_periodic
     end
 
-    def test_assert_missions_in_route_exist
-      problem = VRP.scheduling
-      problem[:routes] = [{
-        vehicle_id: 'vehicle_0',
-        indice: 0,
-        mission_ids: ['service_1', 'service_3']
-      }]
-      refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(TestHelper.create(problem)), :assert_missions_in_routes_do_exist
-
-      problem[:routes] = [{
-        vehicle_id: 'vehicle_0',
-        indice: 0,
-        mission_ids: ['service_111', 'service_3']
-      }]
-      assert_raises OptimizerWrapper::DiscordantProblemError do
-        TestHelper.create(problem)
-      end
-    end
-
     def test_not_too_many_visits_provided_in_route
       problem = VRP.scheduling
       problem[:routes] = [{
@@ -174,32 +155,6 @@ class InstanceValidityTest < Minitest::Test
 
       problem[:configuration][:preprocessing][:first_solution_strategy] = []
       assert_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(TestHelper.create(problem)), :assert_no_route_if_schedule_without_periodic_heuristic
-    end
-
-    def test_same_point_day_authorized
-      vrp = VRP.scheduling
-      reference_point = vrp[:services].first[:activity][:point_id]
-      vrp[:services].first[:visits_number] = 3
-      vrp[:services].first[:minimum_lapse] = 3
-      vrp[:services].first[:maximum_lapse] = 3
-      vrp[:services] << {
-        id: 'last_service',
-        visits_number: 2,
-        minimum_lapse: 6,
-        maximum_lapse: 6,
-        activity: {
-          point_id: reference_point
-        }
-      }
-      vrp[:configuration][:resolution][:same_point_day] = true
-      vrp[:configuration][:schedule][:range_indices][:end] = 10
-      result = OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
-      assert result # there exist a common_divisor
-
-      vrp[:services].last[:minimum_lapse] = vrp[:services].last[:maximum_lapse] = 7
-      assert_raises OptimizerWrapper::UnsupportedProblemError do
-        OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
-      end
     end
   end
 end

--- a/test/lib/interpreters/multi_trips_test.rb
+++ b/test/lib/interpreters/multi_trips_test.rb
@@ -20,65 +20,10 @@ require 'date'
 
 class MultiTripsTest < Minitest::Test
   def test_expand_vehicles_trips
-    size = 5
-    problem = {
-      matrices: [{
-        id: 'matrix_0',
-        time: [
-          [0,  1,  1, 10,  0],
-          [1,  0,  1, 10,  1],
-          [1,  1,  0, 10,  1],
-          [10, 10, 10, 0, 10],
-          [0,  1,  1, 10,  0]
-        ],
-        distance: [
-          [0,  1,  1, 10,  0],
-          [1,  0,  1, 10,  1],
-          [1,  1,  0, 10,  1],
-          [10, 10, 10, 0, 10],
-          [0,  1,  1, 10,  0]
-        ]
-      }],
-      points: (0..(size - 1)).collect{ |i|
-        {
-          id: "point_#{i}",
-          matrix_index: i
-        }
-      },
-      vehicles: [{
-        id: 'vehicle_0',
-        start_point_id: 'point_0',
-        matrix_id: 'matrix_0',
-        timewindow: {
-          start: 1,
-          end: 2
-        },
-        trips: 2
-      }],
-      services: (1..(size - 1)).collect{ |i|
-        {
-          id: "service_#{i}",
-          activity: {
-            point_id: "point_#{i}",
-            timewindows: [{
-              start: 1,
-              end: 2
-            }, {
-              start: 5,
-              end: 7
-            }]
-          }
-        }
-      },
-      configuration: {
-        resolution: {
-          duration: 10
-        }
-      }
-    }
-    vrp = TestHelper.create(problem)
-    periodic = Interpreters::MultiTrips.new
-    periodic.send(:expand, vrp)
+    vrp = VRP.lat_lon
+    vrp[:vehicles].first[:trips] = 2
+
+    vrp = Interpreters::MultiTrips.new.expand(TestHelper.create(vrp))
 
     assert_equal 2, vrp.vehicles.size
     assert_equal 1, vrp.relations.size
@@ -89,7 +34,19 @@ class MultiTripsTest < Minitest::Test
     }
   end
 
+  def test_consecutive_expand
+    vrp = VRP.lat_lon_two_vehicles
+    vrp[:vehicles].first[:trips] = 2
+
+    vrp = TestHelper.create(vrp)
+    Interpreters::MultiTrips.new.expand(vrp)
+    assert_equal 3, vrp.vehicles.size
+    Interpreters::MultiTrips.new.expand(vrp) # consecutive MultiTrips.expand should not produce any error
+    assert_equal 3, vrp.vehicles.size
+  end
+
   def test_solve_vehicles_trips
+    # this test will be cleaned and moved with multi_tour developments
     size = 5
     problem = {
       units: [{

--- a/test/models/vrp_consistency_test.rb
+++ b/test/models/vrp_consistency_test.rb
@@ -1,0 +1,207 @@
+# Copyright © Mapotempo, 2021
+#
+# This file is part of Mapotempo.
+#
+# Mapotempo is free software. You can redistribute it and/or
+# modify since you respect the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Mapotempo is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the Licenses for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Mapotempo. If not, see:
+# <http://www.gnu.org/licenses/agpl.html>
+#
+require './test/test_helper'
+
+module Models
+  class VrpConsistencyTest < Minitest::Test
+    include Rack::Test::Methods
+
+    def test_reject_if_service_with_activities_in_position_relation
+      vrp = VRP.lat_lon_scheduling_two_vehicles
+      vrp[:services].first[:activities] = [vrp[:services].first[:activity]]
+      vrp[:services].first.delete(:activity)
+      vrp[:relations] = [{
+          id: 'force_first',
+          type: 'force_first',
+          linked_ids: [vrp[:services].first[:id]]
+      }]
+
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+          TestHelper.create(vrp)
+      end
+    end
+
+    def test_reject_if_periodic_with_any_relation
+      vrp = VRP.scheduling
+      ['shipment', 'meetup',
+       'same_route', 'sequence', 'order',
+       'minimum_day_lapse', 'maximum_day_lapse', 'minimum_duration_lapse', 'maximum_duration_lapse',
+       'vehicle_group_duration', 'vehicle_group_duration_on_weeks', 'vehicle_group_duration_on_months'].each{ |relation_type|
+        vrp[:relations] = [{
+            type: relation_type,
+            linked_ids: ['service_1', 'service_2']
+        }]
+
+        assert_raises OptimizerWrapper::DiscordantProblemError do
+            TestHelper.create(vrp)
+        end
+      }
+    end
+
+    def test_reject_if_pickup_position_uncompatible_with_delivery
+      vrp = VRP.toy
+      vrp[:shipments] = [{
+          id: 'shipment_0',
+          pickup: {
+          point_id: 'point_0',
+          position: :always_last
+          },
+          delivery: {
+          point_id: 'point_1',
+          position: :always_first
+          }
+      }]
+
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+        TestHelper.create(vrp)
+      end
+    end
+
+    def test_reject_routes_with_activities
+      vrp = VRP.scheduling
+      vrp[:services].first[:activities] = [vrp[:services].first[:activity]]
+      vrp[:services].first.delete(:activity)
+      vrp[:routes] = [{ mission_ids: ['service_1'] }]
+      assert_raises OptimizerWrapper::UnsupportedProblemError do
+        TestHelper.create(vrp)
+      end
+    end
+
+    def test_reject_work_day_partition_with_unconsistent_lapses
+      vrp = VRP.scheduling
+      vrp[:services].each{ |s|
+        s[:visits_number] = 1
+        s[:minimum_lapse] = 2
+        s[:maximum_lapse] = 3
+      }
+      vrp[:configuration][:preprocessing][:partitions] = [{ entity: :work_day }]
+      TestHelper.create(vrp) # no raise
+
+      vrp = VRP.scheduling
+      vrp[:services].each{ |s|
+        s[:visits_number] = 2
+        s[:minimum_lapse] = 2
+      }
+      vrp[:configuration][:preprocessing][:partitions] = [{ entity: :work_day }]
+      TestHelper.create(vrp) # no raise
+
+      vrp = VRP.scheduling
+      vrp[:services].each{ |s|
+        s[:visits_number] = 2
+        s[:minimum_lapse] = 2
+        s[:maximum_lapse] = 3
+      }
+      vrp[:configuration][:preprocessing][:partitions] = [{ entity: :work_day }]
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+        TestHelper.create(vrp)
+      end
+
+      vrp = VRP.scheduling
+      vrp[:services].each{ |s|
+        s[:visits_number] = 2
+        s[:minimum_lapse] = 2
+        s[:maximum_lapse] = 7
+      }
+      vrp[:configuration][:preprocessing][:partitions] = [{ entity: :work_day }]
+      TestHelper.create(vrp) # no raise
+    end
+
+    def test_split_independent_vrp_by_sticky_vehicle
+      vrp = VRP.independent
+      vrp[:services].last[:sticky_vehicle_ids] = ['missing_vehicle_id']
+
+      assert_raises ActiveHash::RecordNotFound do
+        TestHelper.create(vrp)
+      end
+    end
+
+    def test_point_id_not_defined
+      vrp = VRP.basic
+      vrp[:services][0][:activity][:point_id] = 'missing_point_id'
+
+      exception = assert_raises ActiveHash::RecordNotFound do
+        OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
+      end
+      assert_equal('Couldn\'t find Models::Point with ID=missing_point_id', exception.message)
+    end
+
+    def test_same_point_day_authorized
+      vrp = VRP.scheduling
+      reference_point = vrp[:services].first[:activity][:point_id]
+      vrp[:services].first[:visits_number] = 3
+      vrp[:services].first[:minimum_lapse] = 3
+      vrp[:services].first[:maximum_lapse] = 3
+      vrp[:services] << {
+        id: 'last_service',
+        visits_number: 2,
+        minimum_lapse: 6,
+        maximum_lapse: 6,
+        activity: {
+          point_id: reference_point
+        }
+      }
+      vrp[:configuration][:resolution][:same_point_day] = true
+      vrp[:configuration][:schedule][:range_indices][:end] = 10
+      result = OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
+      assert result # there exist a common_divisor
+
+      vrp[:services].last[:minimum_lapse] = vrp[:services].last[:maximum_lapse] = 7
+      assert_raises OptimizerWrapper::UnsupportedProblemError do
+        OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
+      end
+    end
+
+    def test_reject_if_shipments_and_periodic_heuristic
+      vrp = VRP.pud
+      vrp[:configuration][:preprocessing][:first_solution_strategy] = 'periodic'
+      vrp[:configuration][:schedule] = { range_indices: { start: 0, end: 3 }}
+
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+        TestHelper.create(vrp)
+      end
+    end
+
+    def test_reject_if_rests_and_periodic_heuristic
+      vrp = VRP.scheduling
+      vrp[:rests] = [{
+          id: 'rest_0',
+          duration: 1,
+          timewindows: [{
+          day_index: 0
+        }]
+      }]
+      vrp[:vehicles].first[:rests] = ['rest_0']
+
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+          TestHelper.create(vrp)
+      end
+    end
+
+    def test_assert_missions_in_route_exist
+      problem = VRP.basic
+      problem[:routes] = [{
+        vehicle_id: 'vehicle_0',
+        indice: 0,
+        mission_ids: ['service_111', 'service_3']
+      }]
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+        TestHelper.create(problem)
+      end
+    end
+  end
+end

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -956,53 +956,6 @@ class WrapperTest < Minitest::Test
     end
   end
 
-  def test_point_id_not_defined
-    problem = {
-      points: [{
-        id: 'point_0',
-        location: {
-          lat: 1000,
-          lon: 1000
-        }
-      }, {
-        id: 'point_1',
-        location: {
-          lat: 1000,
-          lon: 1000
-        }
-      }],
-      vehicles: [{
-        id: 'vehicle_0',
-        start_point_id: 'point_0',
-        speed_multiplier: 1,
-      }],
-      services: [{
-          id: 'service_0',
-          activity: {
-            point_id: 'point_0'
-          }
-        }, {
-          id: 'service_1',
-          activity: {
-            point_id: 'point_2'
-          }
-      }],
-      configuration: {
-        preprocessing: {
-          cluster_threshold: 5
-        },
-        resolution: {
-          duration: 10
-        }
-      }
-    }
-
-    exception = assert_raises ActiveHash::RecordNotFound do
-      OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(problem), nil)
-    end
-    assert_equal('Couldn\'t find Models::Point with ID=point_2', exception.message)
-  end
-
   def test_geometry_polyline_encoded
     problem = {
       points: [{
@@ -3174,7 +3127,7 @@ class WrapperTest < Minitest::Test
     assert_equal vrp.vehicles.size, result[:routes].size, 'All vehicles should appear in result, even though they can serve no service'
   end
 
-  def test_split_independent_vrp_by_sticky_vehicle
+  def test_split_independent_vrp_by_sticky_vehicle_with_useless_vehicle
     vrp = TestHelper.create(VRP.independent)
     vrp.vehicles << Models::Vehicle.new(id: 'useless_vehicle')
     expected_number_of_vehicles = vrp.vehicles.size


### PR DESCRIPTION
This should help @alain-andre with integration.

test/api/v01/vrp_test.rb fail if we do call
`require './api/root'`

Something has been introduced and breaks this call. This should also be fixed.