### PR TITLE
commpress/decompress dumped files

### DIFF
--- a/lib/cache_manager.rb
+++ b/lib/cache_manager.rb
@@ -15,7 +15,12 @@ class CacheManager
   def read(name, _options = nil)
     filtered_name = name.to_s.parameterize(separator: '')
     if File.exist?(File.join(@cache, filtered_name))
-      Zlib::Inflate.inflate(File.read(File.join(@cache, filtered_name), mode: 'r'))
+      content = File.read(File.join(@cache, filtered_name), mode: 'r')
+      begin
+        Zlib::Inflate.inflate(content)
+      rescue Zlib::DataError # Previously dumped files were not compressed, protect them
+        content
+      end
     end
   rescue StandardError => e
     raise CacheError, "Got error #{e} attempting to read cache #{name}." if !cache.is_a? ActiveSupport::Cache::NullStore

--- a/test/api/v01/output_test.rb
+++ b/test/api/v01/output_test.rb
@@ -95,7 +95,7 @@ class Api::V01::OutputTest < Api::V01::RequestHelper
 
     assert File.exist?(generated_file + '_geojson'), 'Geojson file not found'
     assert File.exist?(generated_file + '_csv'), 'Csv file not found'
-    csv = CSV.read(generated_file + '_csv')
+    csv = CSV.parse(Api::V01::APIBase.dump_vrp_dir.read(file + '_csv'))
 
     assert_equal all_services_vrps.sum{ |service| service[:vrp].services.size } + 1, csv.size
     assert_equal all_services_vrps.size + 1, csv.collect{ |line| line[3] }.uniq!.size
@@ -111,7 +111,7 @@ class Api::V01::OutputTest < Api::V01::RequestHelper
 
     assert File.exist?(generated_file + '_geojson'), 'Geojson file not found'
     assert File.exist?(generated_file + '_csv'), 'Csv file not found'
-    csv = CSV.read(generated_file + '_csv')
+    csv = CSV.parse(Api::V01::APIBase.dump_vrp_dir.read(file + '_csv'))
 
     assert_equal all_services_vrps.sum{ |service| service[:vrp].services.size } + 1, csv.size
     assert_equal all_services_vrps.size + 1, csv.collect{ |line| line[3] }.uniq!.size
@@ -125,18 +125,19 @@ class Api::V01::OutputTest < Api::V01::RequestHelper
     schedule_end = 5
 
     output_tool = OutputHelper::Scheduling.new(name, 'fake_vehicles', job, schedule_end)
-    file_name = File.join(Api::V01::APIBase.dump_vrp_dir.cache, 'scheduling_construction_test_fake_job')
+    file = 'scheduling_construction_test_fake_job'
+    filepath = File.join(Api::V01::APIBase.dump_vrp_dir.cache, file)
 
-    refute File.exist?(file_name), 'File created before end of generation'
+    refute File.exist?(filepath), 'File created before end of generation'
 
     output_tool.add_comment('my comment')
     days = [0, 2, 4]
     output_tool.insert_visits(days, 'service_id', 3)
     output_tool.close_file
 
-    assert File.exist?(file_name), 'File not found'
+    assert File.exist?(filepath), 'File not found'
 
-    csv = CSV.read(file_name)
+    csv = CSV.parse(Api::V01::APIBase.dump_vrp_dir.read(file))
     assert(csv.any?{ |line| line.first == 'my comment' })
     assert(csv.any?{ |line|
       line[0] == 'service_id' &&


### PR DESCRIPTION
To prevent dumped files hitting the size limit.

I verified that everything works as expected by launching some optims on a `mapotempo/dev` server and then I "get" the previously dumped unzipped solutions w/o a problem on a  `feat/zip_dumps` server.

1 - In case needed, `zlib-flate` can be used to inflate a compressed file via terminal.
For a quick look for small enough files:
`zlib-flate -uncompress < /tmp/optimizer-api/dump/file | less` 
and with json syntax
`zlib-flate -uncompress < /tmp/optimizer-api/dump/file | json_pp | less`

To write the content to a file 
`zlib-flate -uncompress < /tmp/optimizer-api/dump/file > content.json`
and with syntax 
`zlib-flate -uncompress < /tmp/optimizer-api/dump/file | json_pp > content.json`

2 - In Ruby
```ruby
require 'zlib'

content = Zlib::Inflate.inflate(File.read('/tmp/optimizer-api/dump/file'))
```

Closes https://gitlab.com/mapotempo/optimizer-api/-/issues/652