### PR TITLE
dicho rests shouldn't be nil inside corresponding_mission_ids

### DIFF
--- a/lib/heuristics/dichotomious_approach.rb
+++ b/lib/heuristics/dichotomious_approach.rb
@@ -208,7 +208,7 @@ module Interpreters
         result[:routes].map{ |route|
           next if route.nil?
 
-          mission_ids = route[:activities].map{ |activity| activity[:service_id] || activity[:rest_id] }.compact
+          mission_ids = route[:activities].map{ |activity| activity[:service_id] }.compact
           next if mission_ids.empty?
 
           Models::Route.new(

--- a/test/lib/heuristics/dichotomious_test.rb
+++ b/test/lib/heuristics/dichotomious_test.rb
@@ -202,5 +202,9 @@ class DichotomiousTest < Minitest::Test
       assert_equal 2, split.size
       assert_equal vrp.services.size, split.collect(&:size).sum, 'Wrong number of services will be returned'
     end
+
+    def test_rest_cannot_appear_as_a_mission_in_the_initial_route
+      assert_empty Interpreters::Dichotomious.send(:build_initial_routes, [{ routes: [activities: [{ rest_id: 'id' }]] }])
+    end
   end
 end

--- a/test/wrappers/ortools_test.rb
+++ b/test/wrappers/ortools_test.rb
@@ -5771,4 +5771,8 @@ class Wrappers::OrtoolsTest < Minitest::Test
 
     assert result[:routes][0][:activities][-2][:rest_id], 'Pause should be at the last spot'
   end
+
+  def test_no_nil_in_corresponding_mission_ids
+    assert_empty OptimizerWrapper.config[:services][:ortools].send(:corresponding_mission_ids, ['only_id'], ['non_id'])
+  end
 end

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -418,9 +418,12 @@ module Wrappers
       routes = vrp.routes.collect{ |route|
         next if route.vehicle.nil? || route.mission_ids.empty?
 
+        service_ids = corresponding_mission_ids(services.collect(&:id), route.mission_ids)
+        next if service_ids.empty?
+
         OrtoolsVrp::Route.new(
           vehicle_id: route.vehicle.id,
-          service_ids: corresponding_mission_ids(services.collect(&:id), route.mission_ids)
+          service_ids: service_ids
         )
       }
 
@@ -822,7 +825,7 @@ module Wrappers
 
         available_ids.delete(correct_id)
         correct_id
-      }
+      }.compact
     end
   end
 end


### PR DESCRIPTION
Closes https://mapotempo.atlassian.net/jira/servicedesk/projects/TICKETS/queues/custom/84/TICKETS-570

This PR basically fixes the following two issues and adds unit tests for each: 

1. In the end phase of dichotomous approach, (due to historical reasons) we include the rest-ids in the initial routes. However, rests are interval variables now and should not be in the initial solution.

2. In the creation of protobuf in `ortools.rb`, we re-collect the IDs and if an ID cannot be found it becomes `nil` which leads to the error `Google::Protobuf::TypeError Invalid argument for string field '' (given NilClass)`.