### PR TITLE
Decrease api memory consumption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '~> 2.5'
 gem 'require_all'
 
 gem 'puma'
-gem 'rack'
+gem 'rack', github: 'senhalil/rack', branch: 'improved-asserts' # remove the custom github definition after the following PR commit is on the stable branch https://github.com/rack/rack/commit/1970771c7e01d54cb631dae0bc7618e2561ad1c7
 gem 'rack-cors'
 gem 'rake'
 gem 'thin'

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'rgeo-geojson'
 
 gem 'google-protobuf', '>=3'
 
+gem 'oj'
 gem 'zlib'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,7 @@ DEPENDENCIES
   minitest-reporters
   minitest-stub_any_instance
   nokogiri
+  oj
   polylines
   puma
   rack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,13 @@ GIT
       color-generator
       geojson2image
 
+GIT
+  remote: https://github.com/senhalil/rack.git
+  revision: a23188bb32972dde155977655f57dea035eee6ea
+  branch: improved-asserts
+  specs:
+    rack (2.2.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -156,7 +163,6 @@ GEM
     polylines (0.3.0)
     puma (5.0.0)
       nio4r (~> 2.0)
-    rack (2.2.3)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-contrib (2.3.0)
@@ -297,7 +303,7 @@ DEPENDENCIES
   oj
   polylines
   puma
-  rack
+  rack!
   rack-contrib
   rack-cors
   rack-test

--- a/api/v01/vrp.rb
+++ b/api/v01/vrp.rb
@@ -147,7 +147,7 @@ module Api
             id = params[:id]
             job = Resque::Plugins::Status::Hash.get(id)
             stored_result = APIBase.dump_vrp_dir.read([id, params[:api_key], 'solution'].join('_'))
-            solution = stored_result && Marshal.load(stored_result) # rubocop:disable Security/MarshalLoad
+            solution = stored_result && Oj.load(stored_result) rescue Marshal.load(stored_result) # rubocop:disable Security/MarshalLoad, Style/RescueModifier
 
             if solution.nil? && (job.nil? || job.killed? || Resque::Plugins::Status::Hash.should_kill?(id) || job['options']['api_key'] != params[:api_key])
               status 404
@@ -159,7 +159,7 @@ module Api
             env['api.format'] = output_format # To override json default format
 
             if job&.completed? # job can still be nil if we have the solution from the dump
-              APIBase.dump_vrp_dir.write([id, params[:api_key], 'solution'].join('_'), Marshal.dump(solution)) if stored_result.nil? && OptimizerWrapper.config[:dump][:solution]
+              APIBase.dump_vrp_dir.write([id, params[:api_key], 'solution'].join('_'), Oj.dump(solution)) if stored_result.nil? && OptimizerWrapper.config[:dump][:solution]
               OptimizerWrapper.job_remove(params[:api_key], id)
             end
 
@@ -178,6 +178,9 @@ module Api
                 }
               }, with: Grape::Presenters::Presenter)
             end
+            # set nil to release memory because puma keeps the grape api endpoint object alive
+            stored_result = nil # rubocop:disable Lint/UselessAssignment
+            solution = nil # rubocop:disable Lint/UselessAssignment
           end
 
           desc 'List vrp jobs', {

--- a/api/v01/vrp.rb
+++ b/api/v01/vrp.rb
@@ -159,8 +159,8 @@ module Api
             env['api.format'] = output_format # To override json default format
 
             if job&.completed? # job can still be nil if we have the solution from the dump
-              OptimizerWrapper.job_remove(params[:api_key], id)
               APIBase.dump_vrp_dir.write([id, params[:api_key], 'solution'].join('_'), Marshal.dump(solution)) if stored_result.nil? && OptimizerWrapper.config[:dump][:solution]
+              OptimizerWrapper.job_remove(params[:api_key], id)
             end
 
             status 200


### PR DESCRIPTION
Decreases the memory allocations from 1.6GB to 1.1GB and the retained memory from 200MB to 151MB for a GET of 28.9MB solution.

```
"GET /0.1/vrp/jobs/x.json?api_key=x HTTP/1.1" 200 28918883 19.7772
```

Before:
```
Total allocated: 1585431963 bytes (20294474 objects)
Total retained:  200831248 bytes (2589749 objects)
```

After:
```
Total allocated: 1126738257 bytes (20266180 objects)
Total retained:  151648381 bytes (1330088 objects)
```