### PR TITLE
Relations and services point to each other

### DIFF
--- a/models/base.rb
+++ b/models/base.rb
@@ -53,7 +53,7 @@ module Models
       super
 
       define_method(name) do
-        self[name] || []
+        self[name] ||= []
       end
 
       define_method("#{name}=") do |vals|

--- a/models/concerns/expand_data.rb
+++ b/models/concerns/expand_data.rb
@@ -45,6 +45,14 @@ module ExpandData
     }
   end
 
+  def add_relation_references
+    self.relations.each{ |relation|
+      relation.linked_services.each{ |service|
+        service.relations << relation
+      }
+    }
+  end
+
   def add_sticky_vehicle_if_routes_and_partitions
     return if self.preprocessing_partitions.empty?
 

--- a/models/relation.rb
+++ b/models/relation.rb
@@ -22,6 +22,7 @@ module Models
     field :type, default: :same_route
     field :lapse, default: nil
     field :linked_ids, default: []
+    has_many :linked_services, class_name: 'Models::Service'
     field :linked_vehicle_ids, default: []
     field :periodicity, default: 1
 

--- a/models/service.rb
+++ b/models/service.rb
@@ -56,5 +56,6 @@ module Models
     has_many :activities, class_name: 'Models::Activity'
     has_many :sticky_vehicles, class_name: 'Models::Vehicle'
     has_many :quantities, class_name: 'Models::Quantity'
+    has_many :relations, class_name: 'Models::Relation'
   end
 end

--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -228,6 +228,7 @@ module Models
     end
 
     def self.expand_data(vrp)
+      vrp.add_relation_references
       vrp.add_sticky_vehicle_if_routes_and_partitions
       vrp.adapt_relations_between_shipments
       vrp.expand_unavailable_days
@@ -325,6 +326,7 @@ module Models
 
       self.remove_unecessary_units(hash)
       self.generate_schedule_indices_from_date(hash)
+      self.generate_linked_service_ids_for_relations(hash)
     end
 
     def self.remove_unecessary_units(hash)
@@ -475,6 +477,14 @@ module Models
       hash[:configuration][:schedule].delete(:range_date)
 
       hash
+    end
+
+    def self.generate_linked_service_ids_for_relations(hash)
+      hash[:relations]&.each{ |relation|
+        next unless relation[:linked_ids]&.any?
+
+        relation[:linked_service_ids] = relation[:linked_ids].select{ |id| hash[:services]&.any?{ |s| s[:id] == id } }
+      }
     end
 
     def configuration=(configuration)


### PR DESCRIPTION
- Prevent uninitialized `has_many` objects (e.g. `vrp.services`, `vrp.relations`, `vehicle.rests`, etc.) returning a different empty array object with each call
- Instead of ids, use actual references inside the relations and vice versa