### PR TITLE
Support relations in split & partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Corresponding vehicle_id is returned within each service's skills if problem is partitioned with vehicle entity [#110](https://github.com/Mapotempo/optimizer-api/pull/110)
 - Support initial routes and skills in split_solve (`max_split_size`) algorithm [#140](https://github.com/Mapotempo/optimizer-api/pull/140)
+- Support relations (`order`, `same_route`, `sequence`, `shipment`) in split_solve algorithm (`max_split_size`) and partitions (`[:configuration][:preprocessing][:partitions]`) [](https://github.com/Mapotempo/optimizer-api/pull/)
+- split_solve algorithm (`max_split_size`) respects relations (`vehicle_trips`, `meetup`, `minimum_duration_lapse`, `maximum_duration_lapse`, `minimum_day_lapse`, `maximum_day_lapse`) [](https://github.com/Mapotempo/optimizer-api/pull/)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Corresponding vehicle_id is returned within each service's skills if problem is partitioned with vehicle entity [#110](https://github.com/Mapotempo/optimizer-api/pull/110)
 - Support initial routes and skills in split_solve (`max_split_size`) algorithm [#140](https://github.com/Mapotempo/optimizer-api/pull/140)
-- Support relations (`order`, `same_route`, `sequence`, `shipment`) in split_solve algorithm (`max_split_size`) and partitions (`[:configuration][:preprocessing][:partitions]`) [](https://github.com/Mapotempo/optimizer-api/pull/)
-- split_solve algorithm (`max_split_size`) respects relations (`vehicle_trips`, `meetup`, `minimum_duration_lapse`, `maximum_duration_lapse`, `minimum_day_lapse`, `maximum_day_lapse`) [](https://github.com/Mapotempo/optimizer-api/pull/)
+- Support relations (`order`, `same_route`, `sequence`, `shipment`) in split_solve algorithm (`max_split_size`) and partitions (`[:configuration][:preprocessing][:partitions]`) [PR145](https://github.com/Mapotempo/optimizer-api/pull/145)
+- split_solve algorithm (`max_split_size`) respects relations (`vehicle_trips`, `meetup`, `minimum_duration_lapse`, `maximum_duration_lapse`, `minimum_day_lapse`, `maximum_day_lapse`) [PR145](https://github.com/Mapotempo/optimizer-api/pull/145)
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'resque-status', '>0.4'
 gem 'rest-client'
 
 gem 'ai4r'
-gem 'balanced_vrp_clustering', github: 'Mapotempo/balanced_vrp_clustering', branch: 'dev'
+gem 'balanced_vrp_clustering', github: 'senhalil/balanced_vrp_clustering', branch: 'dev' # Replace senhalil with Mapotempo when the following PR is merged https://github.com/Mapotempo/balanced_vrp_clustering/pull/16
 gem 'sim_annealing'
 
 gem 'polylines'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,11 @@ GIT
       activesupport (>= 5.0.0)
 
 GIT
-  remote: https://github.com/Mapotempo/balanced_vrp_clustering.git
-  revision: f05b84f49cfc8803ef0adc2bdc12627720d82796
+  remote: https://github.com/senhalil/balanced_vrp_clustering.git
+  revision: 657b71af8721cbbae44c5bba36790fb1c1d6842f
   branch: dev
   specs:
-    balanced_vrp_clustering (0.1.7)
+    balanced_vrp_clustering (0.2.0)
       awesome_print
       color-generator
       geojson2image
@@ -52,7 +52,7 @@ GEM
     anyway_config (2.0.6)
       ruby-next-core (>= 0.8.0)
     ast (2.4.1)
-    awesome_print (1.8.0)
+    awesome_print (1.9.2)
     backport (1.1.2)
     benchmark (0.1.0)
     benchmark-ips (2.8.3)

--- a/api/v01/entities/vrp_input.rb
+++ b/api/v01/entities/vrp_input.rb
@@ -245,7 +245,7 @@ module VrpMisc
   end
 
   params :vrp_request_relation do
-    requires(:type, type: String, allow_blank: false, values: %w[same_route sequence order minimum_day_lapse maximum_day_lapse
+    requires(:type, type: Symbol, allow_blank: false, values: %i[same_route sequence order minimum_day_lapse maximum_day_lapse
                                                                  shipment meetup
                                                                  minimum_duration_lapse maximum_duration_lapse
                                                                  force_first never_first force_end

--- a/lib/heuristics/dichotomious_approach.rb
+++ b/lib/heuristics/dichotomious_approach.rb
@@ -502,7 +502,7 @@ module Interpreters
 
         options[:clusters_infos] = SplitClustering.collect_cluster_data(vrp, nb_clusters)
 
-        clusters = SplitClustering.kmeans_process(nb_clusters, data_items, unit_symbols, limits, options)
+        clusters = SplitClustering.kmeans_process(nb_clusters, data_items, {}, limits, options)
 
         services_by_cluster = clusters.collect{ |cluster|
           cluster.data_items.flat_map{ |data|

--- a/lib/interpreters/multi_trips.rb
+++ b/lib/interpreters/multi_trips.rb
@@ -37,9 +37,9 @@ module Interpreters
             relation.linked_vehicle_ids += new_ids
           }
 
-          vrp.relations += [Models::Relation.new(type: 'vehicle_trips', linked_vehicle_ids: new_ids)]
-          # vrp.relations += [Models::Relation.new(type: 'vehicle_group_duration', linked_vehicle_ids: new_ids, lapse: vehicle.duration)] if vehicle.duration # TODO: Requires a complete rework of overall_duration
-          # vrp.relations += [Models::Relation.new(type: 'vehicle_group_duration', linked_vehicle_ids: new_ids, lapse: vehicle.overall_duration)] if vehicle.overall_duration # TODO: Requires a complete rework of overall_duration
+          vrp.relations += [Models::Relation.new(type: :vehicle_trips, linked_vehicle_ids: new_ids)]
+          # vrp.relations += [Models::Relation.new(type: :vehicle_group_duration, linked_vehicle_ids: new_ids, lapse: vehicle.duration)] if vehicle.duration # TODO: Requires a complete rework of overall_duration
+          # vrp.relations += [Models::Relation.new(type: :vehicle_group_duration, linked_vehicle_ids: new_ids, lapse: vehicle.overall_duration)] if vehicle.overall_duration # TODO: Requires a complete rework of overall_duration
 
           vrp.services.select{ |service| service.sticky_vehicles.any?{ |sticky_vehicle| sticky_vehicle.id == vehicle.id } }.each{ |service|
             service.sticky_vehicles -= [vehicle.id]

--- a/lib/interpreters/periodic_visits.rb
+++ b/lib/interpreters/periodic_visits.rb
@@ -41,7 +41,11 @@ module Interpreters
     def expand(vrp, job, &block)
       return vrp unless vrp.scheduling?
 
-      vehicles_linked_by_duration = save_relations(vrp, 'vehicle_group_duration').concat(save_relations(vrp, 'vehicle_group_duration_on_weeks')).concat(save_relations(vrp, 'vehicle_group_duration_on_months'))
+      vehicles_linked_by_duration = save_relations(vrp, :vehicle_group_duration).concat(
+        save_relations(vrp, :vehicle_group_duration_on_weeks)
+      ).concat(
+        save_relations(vrp, :vehicle_group_duration_on_months)
+      )
       vrp.relations = generate_relations(vrp)
       vrp.rests = []
       vrp.vehicles = generate_vehicles(vrp).sort{ |a, b|
@@ -122,27 +126,27 @@ module Interpreters
       if mission.minimum_lapse && mission.maximum_lapse
         (2..mission.visits_number).each{ |index|
           current_lapse = (index - 1) * mission.minimum_lapse.to_i
-          vrp.relations << Models::Relation.new(type: 'minimum_day_lapse',
+          vrp.relations << Models::Relation.new(type: :minimum_day_lapse,
                                                 linked_ids: ["#{mission.id}_1_#{mission.visits_number}", "#{mission.id}_#{index}_#{mission.visits_number}"],
                                                 lapse: current_lapse)
         }
         (2..mission.visits_number).each{ |index|
           current_lapse = (index - 1) * mission.maximum_lapse.to_i
-          vrp.relations << Models::Relation.new(type: 'maximum_day_lapse',
+          vrp.relations << Models::Relation.new(type: :maximum_day_lapse,
                                                 linked_ids: ["#{mission.id}_1_#{mission.visits_number}", "#{mission.id}_#{index}_#{mission.visits_number}"],
                                                 lapse: current_lapse)
         }
       elsif mission.minimum_lapse
         (2..mission.visits_number).each{ |index|
           current_lapse = mission.minimum_lapse.to_i
-          vrp.relations << Models::Relation.new(type: 'minimum_day_lapse',
+          vrp.relations << Models::Relation.new(type: :minimum_day_lapse,
                                                 linked_ids: ["#{mission.id}_#{index - 1}_#{mission.visits_number}", "#{mission.id}_#{index}_#{mission.visits_number}"],
                                                 lapse: current_lapse)
         }
       elsif mission.maximum_lapse
         (2..mission.visits_number).each{ |index|
           current_lapse = mission.maximum_lapse.to_i
-          vrp.relations << Models::Relation.new(type: 'maximum_day_lapse',
+          vrp.relations << Models::Relation.new(type: :maximum_day_lapse,
                                                 linked_ids: ["#{mission.id}_#{index - 1}_#{mission.visits_number}", "#{mission.id}_#{index}_#{mission.visits_number}"],
                                                 lapse: current_lapse)
         }
@@ -252,7 +256,7 @@ module Interpreters
 
         if vehicle.overall_duration
           new_relation = Models::Relation.new(
-            type: 'vehicle_group_duration',
+            type: :vehicle_group_duration,
             linked_vehicle_ids: @equivalent_vehicles[vehicle.original_id],
             lapse: vehicle.overall_duration + rests_durations[index]
           )
@@ -333,7 +337,7 @@ module Interpreters
       residual_time = []
       idx = 0
       residual_time_for_vehicle = {}
-      vrp.relations.select{ |r| r.type == 'vehicle_group_duration' }.each{ |r|
+      vrp.relations.select{ |r| r.type == :vehicle_group_duration }.each{ |r|
         r.linked_vehicle_ids.each{ |v|
           residual_time_for_vehicle[v] = {
             idx: idx,
@@ -457,7 +461,7 @@ module Interpreters
 
     def get_all_vehicles_in_relation(relations)
       relations&.each{ |r|
-        next if r[:type] == 'vehicle_group_duration'
+        next if r[:type] == :vehicle_group_duration
 
         new_list = []
         r[:linked_vehicle_ids].each{ |v|
@@ -471,9 +475,9 @@ module Interpreters
       new_relations = []
       list.each{ |r|
         case r[:type]
-        when 'vehicle_group_duration'
+        when :vehicle_group_duration
           new_relations << [r[:linked_vehicle_ids], r[:lapse]]
-        when 'vehicle_group_duration_on_weeks'
+        when :vehicle_group_duration_on_weeks
           current_sub_list = []
           first_index = r[:linked_vehicle_ids].min.split('_').last.to_i
           in_periodicity = first_index + 7 * (r[:periodicity] - 1)
@@ -491,7 +495,7 @@ module Interpreters
             end
           }
           new_relations << [current_sub_list, r[:lapse]]
-        when 'vehicle_group_duration_on_months'
+        when :vehicle_group_duration_on_months
           (0..vrp.schedule_months_indices.size - 1).step(r[:periodicity]).collect{ |v| p vrp.schedule_months_indices.slice(v, v + r[:periodicity]).flatten }.each{ |month_indices|
             new_relations << [r[:linked_vehicle_ids].select{ |id| month_indices.include?(id.split('_').last.to_i) }, r[:lapse]]
           }
@@ -500,7 +504,7 @@ module Interpreters
 
       new_relations.each{ |linked_vehicle_ids, lapse|
         vrp.relations << Models::Relation.new(
-          type: 'vehicle_group_duration',
+          type: :vehicle_group_duration,
           linked_vehicle_ids: linked_vehicle_ids,
           lapse: lapse
         )

--- a/lib/interpreters/split_clustering.rb
+++ b/lib/interpreters/split_clustering.rb
@@ -900,7 +900,6 @@ module Interpreters
       end
 
       def collect_data_items_metrics(vrp, cumulated_metrics, options)
-        infeasible_data_items = false
         data_items = []
         grouped_objects = {}
 
@@ -966,8 +965,6 @@ module Interpreters
           characteristics[:duration_from_and_to_depot] = [0, 0] if options[:basic_split]
           data_items << [point.location.lat, point.location.lon, "#{point.id}_#{sub_set_index}", unit_quantities, characteristics, nil]
         }
-
-        log 'There are services in clustering which cannot be served by any vehicles.', level: :warn if infeasible_data_items
 
         zip_dataitems(vrp, data_items, grouped_objects) if options[:group_points] && vrp.matrices.any? && vrp.matrices[0][:distance]&.any?
 

--- a/lib/interpreters/split_clustering.rb
+++ b/lib/interpreters/split_clustering.rb
@@ -384,7 +384,7 @@ module Interpreters
         ) && (
           relation.linked_ids.empty? ||
             relation.linked_ids.any?{ |linked_s_id|
-              vrp.services.any?{ |s| linked_s_id = s.id } ||
+              vrp.services.any?{ |s| linked_s_id == s.id } ||
               vrp.shipments.any? { |s| linked_s_id == "#{s.id}delivery" } ||
               vrp.shipments.any? { |s| linked_s_id == "#{s.id}pickup" }
             }

--- a/lib/interpreters/split_clustering.rb
+++ b/lib/interpreters/split_clustering.rb
@@ -28,6 +28,14 @@ require './lib/output_helper.rb'
 
 module Interpreters
   class SplitClustering
+    # Relations that link multiple services to on the same route
+    LINKING_RELATIONS = %i[
+      order
+      same_route
+      sequence
+      shipment
+    ].freeze
+
     # TODO: private method
     def self.split_clusters(service_vrp, job = nil, &block)
       vrp = service_vrp[:vrp]
@@ -124,14 +132,13 @@ module Interpreters
       vrp = service_vrp[:vrp]
       if service_vrp[:split_level].nil?
         empties_or_fills = vrp.services.select{ |s| s.quantities.any?(&:fill) || s.quantities.any?(&:empty) }
-        depot_ids = vrp.vehicles.flat_map{ |vehicle| [vehicle.start_point_id, vehicle.end_point_id].compact }.uniq
 
         !vrp.scheduling? &&
           vrp.preprocessing_max_split_size &&
           vrp.vehicles.size > 1 &&
           (vrp.resolution_vehicle_limit.nil? || vrp.resolution_vehicle_limit > 1) &&
-          (vrp.shipments.size + vrp.services.size - empties_or_fills.size) > vrp.preprocessing_max_split_size &&
-          vrp.shipments.all?{ |s| depot_ids.include?(s.pickup.point_id) || depot_ids.include?(s.delivery.point_id) }
+          (vrp.services.size - empties_or_fills.size) > vrp.preprocessing_max_split_size &&
+          vrp.shipments.empty? # Clustering supports Shipment only as Relation  TODO: delete this check when Model::Shipment is removed
       else
         ss_data = service_vrp[:split_solve_data]
         current_vehicles = ss_data[:current_vehicles]
@@ -160,9 +167,6 @@ module Interpreters
       # Initialize by first split_by_vehicle and keep the assignment info (don't generate the sub-VRPs yet)
       empties_or_fills = vrp.services.select{ |s| s.quantities.any?(&:fill) || s.quantities.any?(&:empty) }
       vrp.services -= empties_or_fills
-      # TODO: 0- relations needs to be taken into account inside clustering during this split
-      #          - the services need to be in the same route (and by extension, in the same sub-vrp) for the following relations:
-      #            => same_route, order, sequence, shipment
       split_by_vehicle = split_balanced_kmeans(service_vrp, vrp.vehicles.size, cut_symbol: :duration, restarts: 2, build_sub_vrps: false)
 
       # ss_data
@@ -270,14 +274,8 @@ module Interpreters
       sub_vrp.services = ss_data[:current_vehicles].flat_map{ |v| ss_data[:service_vehicle_assignments][v.id] }
       sub_vrp.services.concat ss_data[:transferred_empties_or_fills]
 
-      # fake-shipments are still inside service_vehicle_assignments as services should convert them back
-      # TODO: 0 - With P&D-clustering implementation - Stop treating the "fake-shipments" specially when we support
-      #           shipments in a generic way. The mix of "fake" and "real" shipments will be hard to keep track
-      sub_vrp.shipments = o_vrp.shipments.select{ |ship| sub_vrp.services.reject!{ |ser| ser.id == ship.id } }
-
       # only necessary points -- because compute_matrix doesn't check the difference
       sub_vrp.points = sub_vrp.services.map{ |s| s.activity.point } |
-                       sub_vrp.shipments.flat_map{ |s| [s.pickup.point, s.delivery.point] } |
                        sub_vrp.vehicles.flat_map{ |v| [v.start_point, v.end_point].compact }
 
       # only necessary relations
@@ -298,7 +296,7 @@ module Interpreters
       sub_vrp.configuration = Oj.load(Oj.dump(o_vrp.config)) # time and other limits are correct below
       # split the limits
       sub_vrp.resolution_vehicle_limit = ss_data[:current_vehicle_limit] + ss_data[:transferred_vehicle_limit] if ss_data[:current_vehicle_limit]
-      ratio = (sub_vrp.services.size + 2 * sub_vrp.shipments.size).to_f / (o_vrp.services.size + 2 * o_vrp.shipments.size)
+      ratio = sub_vrp.services.size.to_f / o_vrp.services.size
       sub_vrp.resolution_duration = (o_vrp.resolution_duration * ratio + ss_data[:transferred_time_limit]).ceil if o_vrp.resolution_duration
       sub_vrp.resolution_minimum_duration = (o_vrp.resolution_minimum_duration || o_vrp.resolution_initial_time_out)&.*(ratio)&.ceil
       sub_vrp.resolution_iterations_without_improvment = o_vrp.resolution_iterations_without_improvment&.*(ratio)&.ceil
@@ -378,16 +376,10 @@ module Interpreters
 
         (
           relation.linked_vehicle_ids.empty? ||
-            relation.linked_vehicle_ids.any?{ |linked_v_id|
-              vrp.vehicles.any?{ |v| v.id == linked_v_id }
-            }
+            relation.linked_vehicle_ids.any?{ |id| vrp.vehicles.any?{ |v| v.id == id } }
         ) && (
           relation.linked_ids.empty? ||
-            relation.linked_ids.any?{ |linked_s_id|
-              vrp.services.any?{ |s| linked_s_id == s.id } ||
-              vrp.shipments.any? { |s| linked_s_id == "#{s.id}delivery" } ||
-              vrp.shipments.any? { |s| linked_s_id == "#{s.id}pickup" }
-            }
+            relation.linked_ids.any?{ |id| vrp.services.any?{ |s| s.id == id } }
         )
       }
     end
@@ -623,7 +615,7 @@ module Interpreters
           options[:distance_matrix] = vrp.matrices[0][:time]
         end
 
-        data_items, cumulated_metrics, grouped_objects = collect_data_items_metrics(vrp, cumulated_metrics, options)
+        data_items, cumulated_metrics, grouped_objects, related_item_indices = collect_data_items_metrics(vrp, cumulated_metrics, options)
 
         limits = { metric_limit: centroid_limits(vrp, nb_clusters, data_items, cumulated_metrics, options[:cut_symbol], options[:entity]) } # TODO : remove because this is computed in gem. But it is also needed to compute score here. remove cumulated_metrics at the same time
 
@@ -879,32 +871,11 @@ module Interpreters
         true # if not, they are compatible
       end
 
-      def build_service_like(shipment, activity)
-        Models::Service.new(id: shipment.id,
-                            priority: shipment.priority,
-                            exclusion_cost: shipment.exclusion_cost,
-                            skills: shipment.skills,
-                            activity: activity,
-                            sticky_vehicles: shipment.sticky_vehicles,
-                            quantities: shipment.quantities)
-      end
-
-      def build_services_from_shipments(depot_ids, shipments)
-        shipments.map{ |shipment|
-          if depot_ids.include?(shipment.pickup.point.id)
-            build_service_like(shipment, shipment.delivery)
-          elsif depot_ids.include?(shipment.delivery.point.id)
-            build_service_like(shipment, shipment.pickup)
-          end
-        }.compact
-      end
-
       def collect_data_items_metrics(vrp, cumulated_metrics, options)
         data_items = []
         grouped_objects = {}
 
         vehicle_units = vrp.vehicles.collect{ |v| v.capacities.to_a.collect{ |capacity| capacity.unit.id } }.flatten.uniq
-        depot_ids = vrp.vehicles.collect{ |vehicle| [vehicle.start_point_id, vehicle.end_point_id] }.flatten.compact.uniq
 
         decimal = if !vrp.matrices.empty? && !vrp.matrices[0][:distance]&.empty? # If there is a matrix, zip_dataitems will be called so no need to group by lat/lon aggresively
                     {
@@ -918,26 +889,26 @@ module Interpreters
                     }
                   end
 
-        # TODO: 0- this part needs to be able to handle real shipments
-        custom_shipments = build_services_from_shipments(depot_ids, vrp.shipments)
+        # TODO: this raise can be deleted once the Models::Shipment is replaced with Relations
+        raise UnsupportedProblemError.new('Clustering supports `Shipments` only as `Relations`') if vrp.shipments.any?
 
-        (vrp.services + custom_shipments).group_by{ |s|
+        vrp.services.group_by{ |s|
           location =
             if s.activity
               s.activity.point.location
             elsif s.activities.size.positive?
-              raise UnsupportedProblemError, 'Clustering is not supported yet if one service has serveral activities.'
+              raise UnsupportedProblemError, 'Clustering does not support services with multiple activities.'
             end
 
-          # TODO: 0- this part needs to be able to handle shipment as a relation
+          can_be_grouped = options[:group_points] && s.relations.none?{ |r| LINKING_RELATIONS.include?(r.type) }
           {
             lat: location.lat.round_with_steps(decimal[:digits], decimal[:steps]),
             lon: location.lon.round_with_steps(decimal[:digits], decimal[:steps]),
             v_id: s[:sticky_vehicle_ids].to_a |
-              [vrp.routes.find{ |r| r.mission_ids.include? s.id }&.vehicle_id].compact,
+              [vrp.routes.find{ |r| r.mission_ids.include? s.id }&.vehicle_id].compact, # split respects initial routes
             skills: s.skills.to_a.dup,
             day_skills: compute_day_skills(s.activity&.timewindows),
-            id: options[:group_points] ? nil : s.id
+            do_not_group: can_be_grouped ? nil : s.id, # use the ID to prevent grouping
           }
         }.each_with_index{ |(characteristics, sub_set), sub_set_index|
           unit_quantities = Hash.new(0)
@@ -970,7 +941,22 @@ module Interpreters
 
         add_duration_from_and_to_depot(vrp, data_items) if !options[:basic_split]
 
-        [data_items, cumulated_metrics, grouped_objects]
+        [data_items, cumulated_metrics, grouped_objects, collect_related_item_indices(data_items, grouped_objects)]
+      end
+
+      def collect_related_item_indices(data_items, grouped_objects)
+        related_item_indices = Hash.new { |h, k| h[k] = [] }
+
+        data_items.each_with_index{ |data_item, index|
+          sub_set = grouped_objects[data_item[2]]
+          next unless sub_set.size == 1 # linking_relations are not grouped with others
+
+          sub_set.first.relations.select{ |r| LINKING_RELATIONS.include?(r.type) }.each{ |relation|
+            related_item_indices[relation] << index
+          }
+        }
+
+        related_item_indices.group_by{ |k, _v| k.type }.transform_values!{ |v| v.collect!{ |i| i[1] } }
       end
 
       def zip_dataitems(vrp, items, grouped_objects)
@@ -987,7 +973,10 @@ module Interpreters
 
         c.distance_function = lambda do |data_item_a, data_item_b|
           # If there is no vehicle that can serve both points at the same time, make sure they are not merged
-          return max_distance + 1 if (compatible_vehicles[data_item_a[2]] & compatible_vehicles[data_item_b[2]]).empty?
+          if data_item_a[4][:do_not_group] || data_item_b[4][:do_not_group] ||
+             (compatible_vehicles[data_item_a[2]] & compatible_vehicles[data_item_b[2]]).empty?
+            return max_distance + 1
+          end
 
           [
             vrp.matrices[0][:distance][data_item_a[4][:matrix_index]][data_item_b[4][:matrix_index]],

--- a/models/concerns/expand_data.rb
+++ b/models/concerns/expand_data.rb
@@ -28,18 +28,18 @@ module ExpandData
       services_ids << "#{shipment.id}delivery"
     }
     self.relations.each{ |relation|
-      if %w[minimum_duration_lapse maximum_duration_lapse].include?(relation.type)
+      if %i[minimum_duration_lapse maximum_duration_lapse].include?(relation.type)
         relation.linked_ids[0] = "#{relation.linked_ids[0]}delivery" unless services_ids.include?(relation.linked_ids[0])
         relation.linked_ids[1] = "#{relation.linked_ids[1]}pickup" unless services_ids.include?(relation.linked_ids[1])
 
         relation.lapse ||= 0
-      elsif relation.type == 'same_route'
+      elsif relation.type == :same_route
         relation.linked_ids.each_with_index{ |id, id_i|
           next if services_ids.include?(id)
 
           relation.linked_ids[id_i] = "#{id}pickup" # which will be in same_route as id_delivery
         }
-      elsif %w[sequence order].include?(relation.type)
+      elsif %i[sequence order].include?(relation.type)
         raise OptimizerWrapper::DiscordantProblemError, 'Relation between shipment pickup and delivery should be explicitly specified for relation.' unless (relation.linked_ids - services_ids).empty?
       end
     }

--- a/models/relation.rb
+++ b/models/relation.rb
@@ -31,5 +31,10 @@ module Models
     # validates_numericality_of :lapse, allow_nil: true
     # validates_numericality_of :periodicity, greater_than_or_equal_to: 1
     # validates_inclusion_of :type, :in => %i(same_route sequence order minimum_day_lapse maximum_day_lapse shipment meetup maximum_duration_lapse vehicle_group_duration vehicle_group_duration_on_weeks vehicle_group_duration_on_months vehicle_trips)
+
+    def self.create(hash)
+      hash[:type] = hash[:type]&.to_sym if hash.key?(:type)
+      super(hash)
+    end
   end
 end

--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -239,11 +239,11 @@ module Models
       return unless periodic
 
       if hash[:relations]
-        incompatible_relation_types = hash[:relations].collect{ |r| r[:type] }.uniq - ['force_first', 'never_first', 'force_end']
+        incompatible_relation_types = hash[:relations].collect{ |r| r[:type] }.uniq - %i[force_first never_first force_end]
         raise OptimizerWrapper::DiscordantProblemError, "#{incompatible_relation_types} relations not available with specified first_solution_strategy" unless incompatible_relation_types.empty?
       end
 
-      raise OptimizerWrapper::DiscordantProblemError, 'Vehicle group duration on weeks or months is not available with schedule_range_date.' if hash[:relations].to_a.any?{ |relation| relation[:type] == 'vehicle_group_duration_on_months' } &&
+      raise OptimizerWrapper::DiscordantProblemError, 'Vehicle group duration on weeks or months is not available with schedule_range_date.' if hash[:relations].to_a.any?{ |relation| relation[:type] == :vehicle_group_duration_on_months } &&
                                                                                                                                                 (!configuration[:schedule] || configuration[:schedule][:range_indice])
 
       raise OptimizerWrapper::DiscordantProblemError, 'Shipments are not available with periodic heuristic.' unless hash[:shipments].empty?
@@ -267,7 +267,7 @@ module Models
       relations_to_remove = []
       hash[:relations]&.each_with_index{ |r, r_i|
         case r[:type]
-        when 'force_first'
+        when :force_first
           r[:linked_ids].each{ |id|
             to_modify = [hash[:services], hash[:shipments]].flatten.find{ |s| s[:id] == id }
             raise OptimizerWrapper::DiscordantProblemError, 'Force first relation with service with activities. Use position field instead.' unless to_modify[:activity]
@@ -275,7 +275,7 @@ module Models
             to_modify[:activity][:position] = :always_first
           }
           relations_to_remove << r_i
-        when 'never_first'
+        when :never_first
           r[:linked_ids].each{ |id|
             to_modify = [hash[:services], hash[:shipments]].flatten.find{ |s| s[:id] == id }
             raise OptimizerWrapper::DiscordantProblemError, 'Never first relation with service with activities. Use position field instead.' unless to_modify[:activity]
@@ -283,7 +283,7 @@ module Models
             to_modify[:activity][:position] = :never_first
           }
           relations_to_remove << r_i
-        when 'force_end'
+        when :force_end
           r[:linked_ids].each{ |id|
             to_modify = [hash[:services], hash[:shipments]].flatten.find{ |s| s[:id] == id }
             raise OptimizerWrapper::DiscordantProblemError, 'Force end relation with service with activities. Use position field instead.' unless to_modify[:activity]
@@ -393,7 +393,7 @@ module Models
       return hash unless hash[:relations]&.any?
 
       types_with_duration =
-        %w[minimum_day_lapse maximum_day_lapse
+        %i[minimum_day_lapse maximum_day_lapse
            minimum_duration_lapse maximum_duration_lapse
            vehicle_group_duration vehicle_group_duration_on_weeks
            vehicle_group_duration_on_months vehicle_group_number]

--- a/optimizer_wrapper.rb
+++ b/optimizer_wrapper.rb
@@ -654,7 +654,7 @@ module OptimizerWrapper
                          else
                            (first_service_seen || route[:activities][seen][:travel_time].positive?) ? (route[:activities][seen][:detail][:setup_duration] || 0) : 0
                          end
-      first_service_seen = false if %(w[service pickup delivery]).include?(route[:activities][seen][:type])
+      first_service_seen = false if %w[service pickup delivery].include?(route[:activities][seen][:type])
       route[:activities][seen][:waiting_time] = route[:activities][seen][:begin_time] - (previous_end + considered_setup + (route[:activities][seen][:travel_time] || 0))
       previous_end = route[:activities][seen][:end_time]
       seen += 1

--- a/test/lib/interpreters/interpreter_test.rb
+++ b/test/lib/interpreters/interpreter_test.rb
@@ -703,7 +703,7 @@ class InterpreterTest < Minitest::Test
       }],
       relations: [{
         id: 'id_rel',
-        type: 'meetup',
+        type: :meetup,
         linked_ids: ['shipment_0delivery', 'shipment_1delivery']
       }],
       configuration: {
@@ -1396,7 +1396,7 @@ class InterpreterTest < Minitest::Test
     problem = VRP.basic
     problem[:vehicles] << { id: 'vehicle_1' }
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0', 'vehicle_1'],
       lapse: 10,
       periodicity: 1
@@ -1407,12 +1407,12 @@ class InterpreterTest < Minitest::Test
     expanded_vrp = periodic_expand(problem)
     assert_equal 2, expanded_vrp.relations.size
 
-    problem[:relations].first[:type] = 'vehicle_group_duration'
+    problem[:relations].first[:type] = :vehicle_group_duration
     expanded_vrp = periodic_expand(vrp)
     assert_equal 1,  expanded_vrp.relations.size
     assert_equal 4,  expanded_vrp.relations.first[:linked_vehicle_ids].size
 
-    problem[:relations].first[:type] = 'vehicle_group_duration_on_months'
+    problem[:relations].first[:type] = :vehicle_group_duration_on_months
     problem[:configuration][:schedule] = {
       range_date: { start: Date.new(2020, 1, 31), end: Date.new(2020, 2, 1) }
     }
@@ -1426,7 +1426,7 @@ class InterpreterTest < Minitest::Test
     problem = VRP.basic
     problem[:vehicles] << { id: 'vehicle_1' }
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0', 'vehicle_1'],
       lapse: 10,
       periodicity: 2
@@ -1437,7 +1437,7 @@ class InterpreterTest < Minitest::Test
     expanded_vrp = periodic_expand(problem)
     assert_equal 1, expanded_vrp.relations.size
 
-    problem[:relations].first[:type] = 'vehicle_group_duration_on_months'
+    problem[:relations].first[:type] = :vehicle_group_duration_on_months
     problem[:configuration][:schedule] = {
       range_date: { start: Date.new(2020, 1, 31), end: Date.new(2020, 2, 1) }
     }
@@ -1450,7 +1450,7 @@ class InterpreterTest < Minitest::Test
   def test_expand_relations_of_one_week_and_one_day
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 10
     }]
@@ -1474,7 +1474,7 @@ class InterpreterTest < Minitest::Test
   def test_expand_relations_of_one_month_and_one_day
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_months',
+      type: :vehicle_group_duration_on_months,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 10
     }]

--- a/test/lib/interpreters/multi_trips_test.rb
+++ b/test/lib/interpreters/multi_trips_test.rb
@@ -28,7 +28,7 @@ class MultiTripsTest < Minitest::Test
     assert_equal 2, vrp.vehicles.size
     assert_equal 1, vrp.relations.size
     vrp.relations.each{ |relation|
-      assert_equal 'vehicle_trips', relation.type
+      assert_equal :vehicle_trips, relation.type
       assert_includes relation.linked_vehicle_ids, 'vehicle_0_trip_0'
       assert_includes relation.linked_vehicle_ids, 'vehicle_0_trip_1'
     }

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -139,7 +139,7 @@ class SplitClusteringTest < Minitest::Test
         end
         mock.verify # check if it is called
 
-        data_items, _cumulated_metrics, _linked_objects = Interpreters::SplitClustering.send(:collect_data_items_metrics, TestHelper.create(problem), Hash.new(0), { basic_split: false, group_points: true})
+        data_items, _cumulated_metrics, _grouped_objects = Interpreters::SplitClustering.send(:collect_data_items_metrics, TestHelper.create(problem), Hash.new(0), { basic_split: false, group_points: true})
         assert_equal [200.0, 300.0, 400.0, 500.0], (data_items.flat_map{ |d_i| d_i[4][:duration_from_and_to_depot].uniq }) # check the values are correct
       end
     end

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -840,4 +840,16 @@ class SplitClusteringTest < Minitest::Test
       assert_equal 5, Interpreters::SplitClustering.list_vehicles({ start: 0, end: 4 }, vrp.vehicles, :work_day).size
     end
   end
+
+  def test_select_existing_relations
+    problem = VRP.basic
+    problem[:relations] = [
+      { type: :same_route, linked_ids: ['service_1', 'service_2'] },
+      { type: :same_route, linked_ids: ['service_3'] }
+    ]
+    vrp = TestHelper.create(problem)
+    vrp.services.delete_if{ |s| problem[:relations].first[:linked_ids].include?(s.id) }
+    selected_relations = Interpreters::SplitClustering.select_existing_relations(vrp.relations, vrp)
+    assert_equal 1, selected_relations.size, 'Only the relations of existing services should be selected'
+  end
 end

--- a/test/models/vrp_consistency_test.rb
+++ b/test/models/vrp_consistency_test.rb
@@ -27,7 +27,7 @@ module Models
       vrp[:services].first.delete(:activity)
       vrp[:relations] = [{
           id: 'force_first',
-          type: 'force_first',
+          type: :force_first,
           linked_ids: [vrp[:services].first[:id]]
       }]
 
@@ -38,10 +38,9 @@ module Models
 
     def test_reject_if_periodic_with_any_relation
       vrp = VRP.scheduling
-      ['shipment', 'meetup',
-       'same_route', 'sequence', 'order',
-       'minimum_day_lapse', 'maximum_day_lapse', 'minimum_duration_lapse', 'maximum_duration_lapse',
-       'vehicle_group_duration', 'vehicle_group_duration_on_weeks', 'vehicle_group_duration_on_months'].each{ |relation_type|
+      %i[shipment meetup same_route sequence order
+         minimum_day_lapse maximum_day_lapse minimum_duration_lapse maximum_duration_lapse
+         vehicle_group_duration vehicle_group_duration_on_weeks vehicle_group_duration_on_months].each{ |relation_type|
         vrp[:relations] = [{
             type: relation_type,
             lapse: 1,
@@ -49,7 +48,7 @@ module Models
         }]
 
         assert_raises OptimizerWrapper::DiscordantProblemError do
-            TestHelper.create(vrp)
+          TestHelper.create(vrp)
         end
       }
     end

--- a/test/models/vrp_consistency_test.rb
+++ b/test/models/vrp_consistency_test.rb
@@ -344,5 +344,20 @@ module Models
         Models::Vrp.check_consistency(vrp)
       end
     end
+
+    def test_services_cannot_appear_in_more_than_one_shipment_relation
+      vrp = VRP.basic
+      vrp[:relations] = [
+        { type: :shipment, linked_ids: %w[service_1 service_2] },
+        { type: :shipment, linked_ids: %w[service_1 service_3] }
+      ]
+      error = assert_raises OptimizerWrapper::UnsupportedProblemError do
+        Models::Vrp.check_consistency(TestHelper.coerce(vrp))
+      end
+
+      assert_equal 'Services can appear in at most one shipment relation. '\
+                 'Following services appear in multiple shipment relations',
+                   error.message, 'Error message does not match'
+    end
   end
 end

--- a/test/models/vrp_test.rb
+++ b/test/models/vrp_test.rb
@@ -72,7 +72,7 @@ module Models
     def test_month_indice_generation
       problem = VRP.basic
       problem[:relations] = [{
-        type: 'vehicle_group_duration_on_months',
+        type: :vehicle_group_duration_on_months,
         linked_vehicle_ids: ['vehicle_0'],
         lapse: 2,
         periodicity: 1
@@ -129,7 +129,7 @@ module Models
     def test_deduce_consistent_relations
       vrp = VRP.pud
 
-      ['minimum_duration_lapse', 'maximum_duration_lapse'].each{ |relation_type|
+      %i[minimum_duration_lapse maximum_duration_lapse].each{ |relation_type|
         vrp[:relations] = [{
           type: relation_type,
           linked_ids: ['shipment_0', 'shipment_1'],
@@ -148,7 +148,7 @@ module Models
         activity: { point_id: 'point_1' }
       }]
       vrp[:relations] = [{
-        type: 'minimum_duration_lapse',
+        type: :minimum_duration_lapse,
         linked_ids: ['service', 'shipment_1'],
         lapse: 3
       }]
@@ -157,7 +157,7 @@ module Models
       assert_includes generated_vrp.relations.first.linked_ids, 'shipment_1pickup'
 
       vrp[:relations] = [{
-        type: 'same_route',
+        type: :same_route,
         linked_ids: ['service', 'shipment_0', 'shipment_1'],
         lapse: 3
       }]
@@ -166,7 +166,7 @@ module Models
       assert_includes generated_vrp.relations.first.linked_ids, 'shipment_0pickup'
       assert_includes generated_vrp.relations.first.linked_ids, 'shipment_1pickup'
 
-      %w[sequence order].each{ |relation_type|
+      %i[sequence order].each{ |relation_type|
         vrp[:relations].first[:type] = relation_type
         vrp[:relations].first[:linked_ids] = ['service', 'shipment_1']
         assert_raises OptimizerWrapper::DiscordantProblemError do
@@ -175,7 +175,7 @@ module Models
       }
 
       vrp[:relations].first[:linked_ids] = ['service']
-      %w[sequence order].each{ |relation_type|
+      %i[sequence order].each{ |relation_type|
         vrp[:relations].first[:type] = relation_type
         TestHelper.create(vrp) # check no error provided
       }

--- a/test/models/vrp_test.rb
+++ b/test/models/vrp_test.rb
@@ -281,7 +281,7 @@ module Models
     def test_no_lapse_in_relation
       vrp = VRP.basic
       vrp[:relations] = [{
-        type: 'vehicle_group_duration_on_months',
+        type: :vehicle_group_duration_on_months,
         linked_vehicle_ids: ['vehicle_0']
       }]
 
@@ -289,7 +289,7 @@ module Models
       assert_empty vrp[:relations] # reject relation because lapse is mandatory
 
       vrp[:relations] = [{
-        type: 'vehicle_group_duration_on_months',
+        type: :vehicle_group_duration_on_months,
         linked_vehicle_ids: ['vehicle_0'],
         lapse: 2
       }]
@@ -298,7 +298,7 @@ module Models
 
       vrp = VRP.lat_lon_two_vehicles
       vrp[:relations] = [{
-        type: 'vehicle_trips',
+        type: :vehicle_trips,
         linked_vehicle_ids: vrp[:vehicles].collect{ |v| v[:id] }
       }]
       Models::Vrp.filter(vrp)

--- a/test/real_cases_scheduling_solver_test.rb
+++ b/test/real_cases_scheduling_solver_test.rb
@@ -78,11 +78,11 @@ class HeuristicTest < Minitest::Test
       unassigned_count = Array.new(3){
         vrp = TestHelper.load_vrp(self, fixture_file: 'performance_britanny')
         result = nil
-        Interpreters::SplitClustering.stub(:kmeans_process, lambda{ |nb_clusters, data_items, unit_symbols, limits, options|
+        Interpreters::SplitClustering.stub(:kmeans_process, lambda{ |nb_clusters, data_items, related_item_indices, limits, options|
           options.delete(:distance_matrix)
           options[:restarts] = 4
           # byebug
-          Interpreters::SplitClustering.send(:__minitest_stub__kmeans_process, nb_clusters, data_items, unit_symbols, limits, options) # call original method
+          Interpreters::SplitClustering.send(:__minitest_stub__kmeans_process, nb_clusters, data_items, related_item_indices, limits, options) # call original method
         }) do
           result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, vrp, nil)
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -96,6 +96,8 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
 
     vrp.provide_original_ids unless vrp.is_a?(Hash) # TODO: re-dump with this modification
 
+    vrp[:relations]&.each{ |r| r[:type] = r[:type]&.to_sym } # TODO: re-dump with this modification
+
     vrp
   end
 

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3010,7 +3010,7 @@ class WrapperTest < Minitest::Test
   def test_assert_inapplicable_relations
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration',
+      type: :vehicle_group_duration,
       linked_ids: [],
       linked_vehicle_ids: [],
       lapse: 1
@@ -3021,7 +3021,7 @@ class WrapperTest < Minitest::Test
     refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_relations
 
     problem[:relations] = [{
-      type: 'vehicle_group_duration',
+      type: :vehicle_group_duration,
       linked_ids: ['vehicle_0'],
       linked_vehicle_ids: [],
       lapse: 1

--- a/test/wrappers/ortools_test.rb
+++ b/test/wrappers/ortools_test.rb
@@ -117,7 +117,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
         }
       }],
       relations: [{
-        type: 'vehicle_group_duration',
+        type: :vehicle_group_duration,
         linked_vehicle_ids: ['vehicle_0', 'vehicle_2'],
         lapse: 2
       }],
@@ -159,7 +159,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }]
     }]
     problem[:relations] = [{
-        type: 'vehicle_group_number',
+        type: :vehicle_group_number,
         linked_vehicle_ids: ['vehicle_0', 'vehicle_1', 'vehicle_2'],
         lapse: 2
       }]
@@ -297,7 +297,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
         }
       }],
       relations: [{
-        type: 'vehicle_group_duration',
+        type: :vehicle_group_duration,
         linked_vehicle_ids: ['vehicle_1', 'vehicle_2'],
         lapse: 1
       }],
@@ -540,7 +540,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     skip 'Requires an entire review of the :overall_duration feature'
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_months',
+      type: :vehicle_group_duration_on_months,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 100,
       periodicity: 1
@@ -554,7 +554,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
 
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_months',
+      type: :vehicle_group_duration_on_months,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 6,
       periodicity: 1
@@ -570,7 +570,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     skip 'Requires an entire review of the :overall_duration feature'
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 100,
       periodicity: 1
@@ -583,7 +583,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
 
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 6,
       periodicity: 1
@@ -599,7 +599,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     skip 'Requires an entire review of the :overall_duration feature'
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 100,
       periodicity: 1
@@ -612,7 +612,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
 
     problem = VRP.basic
     problem[:relations] = [{
-      type: 'vehicle_group_duration_on_weeks',
+      type: :vehicle_group_duration_on_weeks,
       linked_vehicle_ids: ['vehicle_0'],
       lapse: 6,
       periodicity: 1
@@ -2980,7 +2980,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       relations: [{
         id: 'minimum_lapse_1',
-        type: 'minimum_day_lapse',
+        type: :minimum_day_lapse,
         lapse: 2,
         linked_ids: ['service_1', 'service_2', 'service_3']
       }],
@@ -3097,12 +3097,12 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       relations: [{
         id: 'maximum_lapse_1',
-        type: 'maximum_day_lapse',
+        type: :maximum_day_lapse,
         lapse: 1,
         linked_ids: ['service_1', 'service_2']
       }, {
         id: 'maximum_lapse_2',
-        type: 'maximum_day_lapse',
+        type: :maximum_day_lapse,
         lapse: 1,
         linked_ids: ['service_1', 'service_3']
       }],
@@ -3463,11 +3463,11 @@ class Wrappers::OrtoolsTest < Minitest::Test
     problem[:shipments][0][:delivery][:timewindows] = [{ start: 300, end: 400 }]
     problem[:shipments][1][:delivery][:timewindows] = [{ start: 100, end: 200 }]
     problem[:relations] = [{
-      type: 'maximum_duration_lapse',
+      type: :maximum_duration_lapse,
       lapse: 100,
       linked_ids: ['shipment_0pickup', 'shipment_0delivery']
     }, {
-      type: 'maximum_duration_lapse',
+      type: :maximum_duration_lapse,
       lapse: 100,
       linked_ids: ['shipment_1pickup', 'shipment_1delivery']
     }]
@@ -3697,7 +3697,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       relations: [{
         id: 'sequence_1',
-        type: 'sequence',
+        type: :sequence,
         linked_ids: ['service_1', 'service_3', 'service_2']
       }],
       configuration: {
@@ -3906,7 +3906,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     problem[:vehicles].each{ |v| v[:start_point_id] = nil }
     problem[:relations] = [{
       id: 'force_first',
-      type: 'force_first',
+      type: :force_first,
       linked_ids: ['service_1', 'service_3']
     }]
 
@@ -3929,11 +3929,11 @@ class Wrappers::OrtoolsTest < Minitest::Test
     problem[:vehicles].each{ |v| v[:start_point_id] = nil }
     problem[:relations] = [{
       id: 'force_end',
-      type: 'force_end',
+      type: :force_end,
       linked_ids: ['service_1']
     }, {
       id: 'force_end2',
-      type: 'force_end',
+      type: :force_end,
       linked_ids: ['service_3']
     }]
 
@@ -3956,7 +3956,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     problem[:vehicles].each{ |v| v[:start_point_id] = nil }
     problem[:relations] = [{
       id: 'never_first',
-      type: 'never_first',
+      type: :never_first,
       linked_ids: ['service_1', 'service_3']
     }]
 
@@ -4063,7 +4063,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       relations: [{
         id: 'never_first',
-        type: 'never_first',
+        type: :never_first,
         linked_ids: ['service_1', 'service_3']
       }],
       configuration: {
@@ -5339,11 +5339,11 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       relations: [{
         id: 1,
-        type: 'order',
+        type: :order,
         linked_ids: ['service_1', 'service_2', 'service_3']
       }, {
         id: 2,
-        type: 'order',
+        type: :order,
         linked_ids: ['service_4', 'service_5']
       }],
       configuration: {
@@ -5553,7 +5553,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     assert_equal result[:routes].first[:activities][first_index][:begin_time], result[:routes].first[:activities][second_index][:begin_time]
 
     vrp[:relations] = [{
-      type: 'minimum_duration_lapse',
+      type: :minimum_duration_lapse,
       linked_ids: ['service_1', 'service_2'],
       lapse: 10
     }]
@@ -5574,7 +5574,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
     current_order.compact!
 
     # add consecutivity :
-    relation = Models::Relation.new(type: 'minimum_duration_lapse', linked_ids: [current_order[1], current_order[0]], lapse: 1800)
+    relation = Models::Relation.new(type: :minimum_duration_lapse, linked_ids: [current_order[1], current_order[0]], lapse: 1800)
     vrp.relations = [relation]
     vrp.adapt_relations_between_shipments
     result = OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:ortools] }}, vrp, nil)

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -79,7 +79,7 @@ module Wrappers
 
     def solve(vrp, job, thread_proc = nil, &block)
       tic = Time.now
-      order_relations = vrp.relations.select{ |relation| relation.type == 'order' }
+      order_relations = vrp.relations.select{ |relation| relation.type == :order }
       already_begin = order_relations.collect{ |relation| relation.linked_ids[0..-2] }.flatten
       duplicated_begins = already_begin.uniq.select{ |linked_id| already_begin.select{ |link| link == linked_id }.size > 1 }
       already_end = order_relations.collect{ |relation| relation.linked_ids[1..-1] }.flatten
@@ -214,20 +214,20 @@ module Wrappers
           }.compact
         end
         relations << OrtoolsVrp::Relation.new(
-          type: 'shipment',
+          type: :shipment,
           linked_ids: [shipment.id + 'pickup', shipment.id + 'delivery'],
           lapse: -1
         )
         if shipment.maximum_inroute_duration&.positive?
           relations << OrtoolsVrp::Relation.new(
-            type: 'maximum_duration_lapse',
+            type: :maximum_duration_lapse,
             linked_ids: [shipment.id + 'pickup', shipment.id + 'delivery'],
             lapse: shipment.maximum_inroute_duration
           )
         end
         if shipment.direct
           relations << OrtoolsVrp::Relation.new(
-            type: 'sequence',
+            type: :sequence,
             linked_ids: [shipment.id + 'pickup', shipment.id + 'delivery']
           )
         end
@@ -413,7 +413,7 @@ module Wrappers
         next if current_linked_ids.empty? && current_linked_vehicles.empty?
 
         OrtoolsVrp::Relation.new(
-          type: relation.type.to_s,
+          type: relation.type,
           linked_ids: current_linked_ids,
           linked_vehicle_ids: current_linked_vehicles,
           lapse: relation.lapse
@@ -432,10 +432,10 @@ module Wrappers
         )
       }
 
-      relations << OrtoolsVrp::Relation.new(type: 'force_first', linked_ids: services_positions[:always_first], lapse: -1) unless services_positions[:always_first].empty?
-      relations << OrtoolsVrp::Relation.new(type: 'never_first', linked_ids: services_positions[:never_first], lapse: -1) unless services_positions[:never_first].empty?
-      relations << OrtoolsVrp::Relation.new(type: 'never_last', linked_ids: services_positions[:never_last], lapse: -1) unless services_positions[:never_last].empty?
-      relations << OrtoolsVrp::Relation.new(type: 'force_end', linked_ids: services_positions[:always_last], lapse: -1) unless services_positions[:always_last].empty?
+      relations << OrtoolsVrp::Relation.new(type: :force_first, linked_ids: services_positions[:always_first], lapse: -1) unless services_positions[:always_first].empty?
+      relations << OrtoolsVrp::Relation.new(type: :never_first, linked_ids: services_positions[:never_first], lapse: -1) unless services_positions[:never_first].empty?
+      relations << OrtoolsVrp::Relation.new(type: :never_last, linked_ids: services_positions[:never_last], lapse: -1) unless services_positions[:never_last].empty?
+      relations << OrtoolsVrp::Relation.new(type: :force_end, linked_ids: services_positions[:always_last], lapse: -1) unless services_positions[:always_last].empty?
 
       problem = OrtoolsVrp::Problem.new(
         vehicles: vehicles,

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -282,9 +282,9 @@ module Wrappers
     end
 
     def assert_no_overall_duration(vrp)
-      relation_array = %w[vehicle_group_duration vehicle_group_duration_on_weeks vehicle_group_duration_on_months]
+      relation_array = %i[vehicle_group_duration vehicle_group_duration_on_weeks vehicle_group_duration_on_months]
       vrp.vehicles.none?(&:overall_duration) &&
-        vrp.relations.none?{ |relation| relation_array.include?(relation.type) }
+        vrp.relations.none?{ |relation| relation_array.include?(relation.type&.to_sym) }
     end
 
     def assert_no_vehicle_distance_if_heuristic(vrp)


### PR DESCRIPTION
Adds relations support to split_solve & partitions

LINKING_RELATIONS := Relations that link multiple services to be on the same route 
        (order, same_route, sequence, shipment) are supported in 
	split_solve algorithm (`max_split_size`) and
	partitions (`[:configuration][:preprocessing][:partitions]`)

FORCING_RELATIONS := Relations that force multiple services/vehicle to stay in the same VRP 
	(vehicle_trips, meetup, minimum_duration_lapse, maximum_duration_lapse, minimum_day_lapse, maximum_day_lapse)
	are respected by split_solve (`max_split_size`) algorithm

- [ ] Needs https://github.com/Mapotempo/balanced_vrp_clustering/pull/16 to be merged and Gemfile/Gemfile.lock corrected/updated

Closes 291, 544, 564, 634