### PR TITLE
Relations and vehicles reference each other

### DIFF
--- a/models/concerns/expand_data.rb
+++ b/models/concerns/expand_data.rb
@@ -50,6 +50,9 @@ module ExpandData
       relation.linked_services.each{ |service|
         service.relations << relation
       }
+      relation.linked_vehicles.each{ |vehicle|
+        vehicle.relations << relation
+      }
     }
   end
 

--- a/models/relation.rb
+++ b/models/relation.rb
@@ -24,6 +24,7 @@ module Models
     field :linked_ids, default: []
     has_many :linked_services, class_name: 'Models::Service'
     field :linked_vehicle_ids, default: []
+    has_many :linked_vehicles, class_name: 'Models::Vehicle'
     field :periodicity, default: 1
 
     # ActiveHash doesn't validate the validator of the associated objects

--- a/models/vehicle.rb
+++ b/models/vehicle.rb
@@ -104,6 +104,7 @@ module Models
     has_many :capacities, class_name: 'Models::Capacity'
     # include ValidateTimewindows # <- This doesn't work
     has_many :rests, class_name: 'Models::Rest'
+    has_many :relations, class_name: 'Models::Relation'
 
     def self.create(hash)
       if hash[:sequence_timewindows]&.size&.positive? && hash[:unavailable_days]&.size&.positive? # X&.size&.positive? is not the same as !X&.empty?


### PR DESCRIPTION
@fonsecadeline I had to remove the vehicle relation from #144 because it is not compatible with the actual multi tour expansion logic. Since the expansion of the `trip` parameter is inside the optimizerwrapper and uses Marshal.dump/load the `base.rb` cannot "see" these new vehicles and the trip relation generated  inside this expansion function cannot point to these vehicles. We need to move the expansion of the `vehicle[:trips]` before the create function so that inside the code we only maintain one way -- trips as relations. 