### PR TITLE
fix duplicate_safe function

### DIFF
--- a/lib/interpreters/periodic_visits.rb
+++ b/lib/interpreters/periodic_visits.rb
@@ -510,7 +510,7 @@ module Interpreters
     private
 
     def get_original_values(original, options)
-      [original.attributes.keys + options.keys - [:unavailable_work_day_indices] + [:unavailable_days]].flatten.each_with_object({}) { |key, data|
+      [original.attributes.keys + options.keys].flatten.each_with_object({}) { |key, data|
         next if [:sticky_vehicle_ids, :quantity_ids,
                  :start_point_id, :end_point_id, :capacity_ids, :sequence_timewindow_ids, :timewindow_id].include?(key)
 


### PR DESCRIPTION
Latter modifications (https://github.com/Mapotempo/optimizer-api/pull/139) were not consistent but we still need some cleaning then.