### PR TITLE
range start and end are mandatory

### DIFF
--- a/api/v01/entities/vrp_input.rb
+++ b/api/v01/entities/vrp_input.rb
@@ -224,13 +224,13 @@ module VrpConfiguration
   end
 
   params :vrp_request_indice_range do
-    optional(:start, type: Integer, desc: 'Beginning of the range')
-    optional(:end, type: Integer, desc: 'End of the range')
+    requires(:start, type: Integer, desc: 'Beginning of the range')
+    requires(:end, type: Integer, desc: 'End of the range')
   end
 
   params :vrp_request_date_range do
-    optional(:start, type: Date, desc: 'Beginning of the range in date format')
-    optional(:end, type: Date, desc: 'End of the range in date format')
+    requires(:start, type: Date, desc: 'Beginning of the range in date format')
+    requires(:end, type: Date, desc: 'End of the range in date format')
   end
 end
 

--- a/test/api/v01/vrp_test.rb
+++ b/test/api/v01/vrp_test.rb
@@ -360,4 +360,12 @@ class Api::V01::VrpTest < Minitest::Test
       key =~ /(Content-Type|X-RateLimit-Limit|X-RateLimit-Remaining|X-RateLimit-Reset)/
     }.values
   end
+
+  def test_submit_without_schedule_start_should_break
+    vrp_no_sched_start = VRP.scheduling
+    vrp_no_sched_start[:configuration][:schedule] = { range_indices: { start: 0 } }
+    post '/0.1/vrp/submit', {api_key: 'demo', vrp: vrp_no_sched_start}.to_json, 'CONTENT_TYPE' => 'application/json'
+    assert_equal 400, last_response.status
+    assert_includes(JSON.parse(last_response.body)['message'], 'vrp[configuration][schedule][range_indices][end] is missing')
+  end
 end

--- a/test/models/vrp_consistency_test.rb
+++ b/test/models/vrp_consistency_test.rb
@@ -32,7 +32,7 @@ module Models
       }]
 
       assert_raises OptimizerWrapper::DiscordantProblemError do
-          TestHelper.create(vrp)
+        TestHelper.create(vrp)
       end
     end
 


### PR DESCRIPTION
Fix for : https://gitlab.com/mapotempo/optimizer-api/-/issues/691