### PR TITLE
Warn instead for raising when date used with day indices

### DIFF
--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -460,9 +460,11 @@ module Models
       }
       if (hash[:configuration][:schedule][:range_indices] && has_date) ||
          (hash[:configuration][:schedule][:range_date] && has_index)
-        raise OptimizerWrapper::DiscordantProblemError.new(
-          'Date intervals are not compatible with schedule range indices'
-        )
+        log 'Dates and day indices used at the same time', level: :warn
+        # TODO : replace by raise when customers are ready
+        # raise OptimizerWrapper::DiscordantProblemError.new(
+        #   'Date intervals are not compatible with schedule range indices'
+        # )
       end
     end
 

--- a/test/models/vrp_consistency_test.rb
+++ b/test/models/vrp_consistency_test.rb
@@ -304,6 +304,7 @@ module Models
     end
 
     def test_dates_cannot_be_mixed_with_indices
+      skip 'This should not be skipped after https://gitlab.com/mapotempo/optimizer-api/-/issues/705 is done'
       vrp = VRP.scheduling # contains schedule[:range_indices]
       vrp[:vehicles].first[:unavailable_work_date] = [Date.new(2021, 2, 11)]
 


### PR DESCRIPTION
Temporary modification in order to let our users time to adapt their process.