### PR TITLE
Reduce vroom time thread consumption

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,7 +39,7 @@ module OptimizerWrapper
   HEURISTICS = %w[path_cheapest_arc global_cheapest_arc local_cheapest_insertion savings parallel_cheapest_insertion first_unbound christofides].freeze
   WEEKDAYS = %i[mon tue wed thu fri sat sun].freeze
   DEMO = Wrappers::Demo.new(tmp_dir: TMP_DIR)
-  VROOM = Wrappers::Vroom.new(tmp_dir: TMP_DIR)
+  VROOM = Wrappers::Vroom.new(tmp_dir: TMP_DIR, threads: 1)
   # if dependencies don't exist (libprotobuf10 on debian) provide or-tools dependencies location
   ORTOOLS_EXEC = 'LD_LIBRARY_PATH=../or-tools/dependencies/install/lib/:../or-tools/lib/ ../optimizer-ortools/tsp_simple'.freeze
   ORTOOLS = Wrappers::Ortools.new(tmp_dir: TMP_DIR, exec_ortools: ORTOOLS_EXEC)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ module OptimizerWrapper
   HEURISTICS = %w[path_cheapest_arc global_cheapest_arc local_cheapest_insertion savings parallel_cheapest_insertion first_unbound christofides].freeze
   WEEKDAYS = %i[mon tue wed thu fri sat sun].freeze
   DEMO = Wrappers::Demo.new(tmp_dir: TMP_DIR, threads: 4)
-  VROOM = Wrappers::Vroom.new(tmp_dir: TMP_DIR, threads: 4)
+  VROOM = Wrappers::Vroom.new(tmp_dir: TMP_DIR, threads: 1)
   # if dependencies don't exist (libprotobuf10 on debian) provide or-tools dependencies location
   ORTOOLS_EXEC = 'LD_LIBRARY_PATH=../or-tools/dependencies/install/lib/:../or-tools/lib/ ../optimizer-ortools/tsp_simple'.freeze
   ORTOOLS = Wrappers::Ortools.new(tmp_dir: TMP_DIR, exec_ortools: ORTOOLS_EXEC, threads: 4)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,7 +38,7 @@ module OptimizerWrapper
   HEURISTICS = %w[path_cheapest_arc global_cheapest_arc local_cheapest_insertion savings parallel_cheapest_insertion first_unbound christofides].freeze
   WEEKDAYS = %i[mon tue wed thu fri sat sun].freeze
   DEMO = Wrappers::Demo.new(tmp_dir: TMP_DIR)
-  VROOM = Wrappers::Vroom.new(tmp_dir: TMP_DIR)
+  VROOM = Wrappers::Vroom.new(tmp_dir: TMP_DIR, threads: 1)
   # if dependencies don't exist (libprotobuf10 on debian) provide or-tools dependencies location
   ORTOOLS_EXEC = 'LD_LIBRARY_PATH=../or-tools/dependencies/install/lib/:../or-tools/lib/ ../optimizer-ortools/tsp_simple'.freeze
   ORTOOLS = Wrappers::Ortools.new(tmp_dir: TMP_DIR, exec_ortools: ORTOOLS_EXEC)

--- a/test/models/vrp_consistency_test.rb
+++ b/test/models/vrp_consistency_test.rb
@@ -368,5 +368,14 @@ module Models
       end
       assert_equal "There are vehicles or services with 'vehicle_partition_*', 'work_day_partition_*' skills. These skill patterns are reserved for internal use and they would lead to unexpected behaviour.", error.message
     end
+
+    def test_reject_when_duplicated_ids
+      vrp = VRP.toy
+      vrp[:services] << vrp[:services].first
+
+      assert_raises OptimizerWrapper::DiscordantProblemError do
+        OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
+      end
+    end
   end
 end

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3061,6 +3061,15 @@ class WrapperTest < Minitest::Test
     refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_first_solution_strategy
   end
 
+  def test_vroom_not_called_if_max_split_lower_thant_services_size
+    problem = VRP.lat_lon_two_vehicles
+    assert_empty OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(TestHelper.create(problem))
+
+    problem[:configuration][:preprocessing] = { max_split_size: 2 }
+    assert_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(TestHelper.create(problem)),
+                    :assert_not_a_split_solve_candidate
+  end
+
   def test_reject_when_duplicated_ids
     vrp = VRP.toy
     vrp[:services] << vrp[:services].first

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3069,13 +3069,4 @@ class WrapperTest < Minitest::Test
     assert_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(TestHelper.create(problem)),
                     :assert_not_a_split_solve_candidate
   end
-
-  def test_reject_when_duplicated_ids
-    vrp = VRP.toy
-    vrp[:services] << vrp[:services].first
-
-    assert_raises OptimizerWrapper::DiscordantProblemError do
-      OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.create(vrp), nil)
-    end
-  end
 end

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -25,6 +25,7 @@ module Wrappers
     def initialize(hash = {})
       super(hash)
       @exec_vroom = hash[:exec_vroom] || '../vroom/bin/vroom'
+      @exec_vroom += " -t #{hash[:threads]}" if hash[:threads]
     end
 
     def solver_constraints

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -386,7 +386,8 @@ module Wrappers
       output = Tempfile.new('optimize-vroom-output', @tmp_dir)
       output.close
 
-      cmd = "#{@exec_vroom} -i '#{input.path}' -o '#{output.path}'"
+      # TODO : find best value for x https://github.com/Mapotempo/optimizer-api/pull/203
+      cmd = "#{@exec_vroom} -i '#{input.path}' -o '#{output.path}' -x 0"
       log cmd
       system(cmd)
 

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -43,6 +43,7 @@ module Wrappers
         :assert_no_subtours,
         :assert_points_same_definition,
         :assert_single_dimension,
+        :assert_not_a_split_solve_candidate,
 
         # Vehicle/route constraints
         :assert_homogeneous_router_definitions,

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -449,6 +449,10 @@ module Wrappers
         }
     end
 
+    def assert_not_a_split_solve_candidate(vrp)
+      !Interpreters::SplitClustering.split_solve_candidate?({ vrp: vrp })
+    end
+
     def solve_synchronous?(_vrp)
       false
     end


### PR DESCRIPTION
Some tests are still running to chose right value for X : 

- x 0 - 5, 6 minutes (Solution cost: 515723 & unassigned: 0)
- x 1 - 9 minutes (Solution cost: 515723 & unassigned: 0)
- x 2 - 14 minutes (Solution cost: 515723 & unassigned: 0)

I suggest using 0 not to take any risks without testing (we only tested on one instance)