### PR TITLE
Fix: Vroom handles quantities correctly

### DIFF
--- a/test/wrappers/vroom_test.rb
+++ b/test/wrappers/vroom_test.rb
@@ -792,6 +792,18 @@ class Wrappers::VroomTest < Minitest::Test
     }
   end
 
+  def test_negative_quantities_should_not_raise
+    problem = VRP.basic
+    problem[:units] << { id: 'l' }
+    problem[:services].each{ |service|
+      service[:quantities] = [{ unit_id: 'kg', value: 1 }, { unit_id: 'l', value: -1}]
+    }
+    problem[:vehicles].each{ |vehicle|
+      vehicle[:capacities] = [{ unit_id: 'kg', limit: 3 }, { unit_id: 'l', limit: 2}]
+    }
+    OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:vroom] }}, TestHelper.create(problem), nil)
+  end
+
   def test_partially_nil_capacities
     problem = VRP.basic
     problem[:services].each{ |service|

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -274,7 +274,7 @@ module Wrappers
           delivery: vrp_units.map{ |unit|
             q = service.quantities.find{ |quantity| quantity.unit.id == unit.id && quantity.value.negative? }
             @total_quantities[unit.id] -= q&.value || 0
-            ((q&.value || 0) * CUSTOM_QUANTITY_BIGNUM).round
+            (-(q&.value || 0) * CUSTOM_QUANTITY_BIGNUM).round
           },
           pickup: vrp_units.map{ |unit|
             q = service.quantities.find{ |quantity| quantity.unit.id == unit.id && quantity.value.positive? }

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -51,6 +51,7 @@ module Wrappers
         :assert_homogeneous_router_definitions,
         :assert_matrices_only_one,
         :assert_no_distance_limitation,
+        :assert_no_vehicles_with_duration_modifiers,
         :assert_vehicles_no_duration_limit,
         :assert_vehicles_no_force_start,
         :assert_vehicles_no_late_multiplier_or_single_vehicle,

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -381,6 +381,16 @@ module Wrappers
       }
     end
 
+    def assert_no_vehicles_with_duration_modifiers(vrp)
+      # TODO: this assert can be relaxed by implementing a simplifier
+      # if all vehicles are homogenous w.r.t. a given duration_modifier,
+      # then we can update the durations directly and rewind it easily
+      vrp.vehicles.all?{ |vehicle|
+        (vehicle.coef_setup.nil? || vehicle.coef_setup == 1) && vehicle.additional_setup.to_i == 0 &&
+          (vehicle.coef_service.nil? || vehicle.coef_service == 1) && vehicle.additional_service.to_i == 0
+      }
+    end
+
     def assert_homogeneous_router_definitions(vrp)
       vrp.vehicles.group_by{ |vehicle|
         [vehicle.router_mode, vehicle.dimensions, vehicle.router_options]


### PR DESCRIPTION
Vroom expects all quantities to be positive (delivery quantities are multiplied with -1)
It cannot handle durations begin modified by vehicle (assert added)
It shouldn't silently ignore services (both pickup and delivery amounts are sent to the solver)