### PR TITLE
collect_items and Vroom can handle shipment relations

### DIFF
--- a/models/vehicle.rb
+++ b/models/vehicle.rb
@@ -232,7 +232,7 @@ module Models
     end
 
     def work_duration
-      raise OptimizerWrapper::DiscordantProblemError, 'Vehicle should not have sequence timewindow if there is no schedule' unless self.sequence_timewindows.empty?
+      raise 'vehicle::work_duration cannot handle sequence_timewindow' if self.sequence_timewindows.any?
 
       timewindow_duration =
         if self.timewindow&.end

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -661,8 +661,9 @@ class SplitClusteringTest < Minitest::Test
       Interpreters::SplitClustering::LINKING_RELATIONS.each_with_index{ |relation, index|
         problem[:relations] << { type: relation, linked_ids: [] }
         n_service_per_relation.times.each{ |i|
-          problem[:services] << dummy_service.dup
+          problem[:services] << Oj.load(Oj.dump(dummy_service))
           problem[:services].last[:id] = "service_#{relation}_#{i}"
+          problem[:services].last[:activity][:point_id] = "point_#{i}"
           problem[:relations].last[:linked_ids] << problem[:services].last[:id]
         }
         expected_linked_items[relation] << Array.new(n_service_per_relation){ |i| index * n_service_per_relation + i }

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -27,7 +27,7 @@ module Models
 
       # work duration is only supposed to be called when there is no schedule
       # therefore, work_duration should not be called if vehicle has sequence_timewindows
-      assert_raises OptimizerWrapper::DiscordantProblemError do
+      assert_raises do
         vrp.vehicles.first.work_duration
       end
 

--- a/test/real_cases_scheduling_solver_test.rb
+++ b/test/real_cases_scheduling_solver_test.rb
@@ -64,7 +64,7 @@ class HeuristicTest < Minitest::Test
         result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, vrp, nil)
         unassigned_nb + result[:unassigned].size
       }
-      assert unassigned_visits <= 225, "Expecting less than 441 unassigned visits, have #{unassigned_visits}"
+      assert_operator unassigned_visits, :<=, 225, 'Expecting less unassigned visits'
     end
 
     def test_performance_britanny_with_solver

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3062,13 +3062,14 @@ class WrapperTest < Minitest::Test
     refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_first_solution_strategy
   end
 
-  def test_vroom_not_called_if_max_split_lower_thant_services_size
+  def test_vroom_cannot_be_called_synchronously_if_max_split_lower_than_services_size
     problem = VRP.lat_lon_two_vehicles
     assert_empty OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(TestHelper.create(problem))
+    assert OptimizerWrapper.config[:services][:vroom].solve_synchronous?(TestHelper.create(problem))
 
     problem[:configuration][:preprocessing] = { max_split_size: 2 }
-    assert_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(TestHelper.create(problem)),
-                    :assert_not_a_split_solve_candidate
+    assert_empty OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(TestHelper.create(problem))
+    refute OptimizerWrapper.config[:services][:vroom].solve_synchronous?(TestHelper.create(problem))
   end
 
   def test_simplify_constraints_simplifies_pause

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3026,11 +3026,14 @@ class WrapperTest < Minitest::Test
       linked_ids: [],
       linked_vehicle_ids: [],
       lapse: 1
+    }, {
+      type: :shipment,
+      linked_ids: ['service_1', 'service_2']
     }]
 
     vrp = TestHelper.create(problem)
-    refute_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(vrp), :assert_no_relations
-    refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_relations
+    refute_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(vrp), :assert_no_relations_except_simple_shipments
+    refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_relations_except_simple_shipments
 
     problem[:relations] = [{
       type: :vehicle_group_duration,
@@ -3040,8 +3043,8 @@ class WrapperTest < Minitest::Test
     }]
 
     vrp = TestHelper.create(problem)
-    assert_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(vrp), :assert_no_relations
-    refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_relations
+    assert_includes OptimizerWrapper.config[:services][:vroom].inapplicable_solve?(vrp), :assert_no_relations_except_simple_shipments
+    refute_includes OptimizerWrapper.config[:services][:ortools].inapplicable_solve?(vrp), :assert_no_relations_except_simple_shipments
   end
 
   def test_solver_needed

--- a/test/wrappers/ortools_test.rb
+++ b/test/wrappers/ortools_test.rb
@@ -441,7 +441,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       configuration: {
         resolution: {
-          duration: 100,
+          duration: 200,
         }
       }
     }
@@ -4379,7 +4379,7 @@ class Wrappers::OrtoolsTest < Minitest::Test
       }],
       configuration: {
         resolution: {
-          duration: 100,
+          duration: 200,
         }
       }
     }

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -80,7 +80,7 @@ module Wrappers
     end
 
     def solve(vrp, job = nil, _thread_proc = nil)
-      if vrp.points.empty? || vrp.services.empty? && vrp.shipments.empty?
+      if vrp.vehicles.empty? || vrp.points.empty? || vrp.services.empty? && vrp.shipments.empty?
         return empty_result('vroom', vrp)
       end
 

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -50,7 +50,7 @@ module Wrappers
         :assert_homogeneous_router_definitions,
         :assert_matrices_only_one,
         :assert_no_distance_limitation,
-        :assert_no_vehicles_with_duration_modifiers,
+        :assert_no_service_duration_modifiers,
         :assert_vehicles_no_duration_limit,
         :assert_vehicles_no_force_start,
         :assert_vehicles_no_late_multiplier_or_single_vehicle,
@@ -60,7 +60,7 @@ module Wrappers
         # Mission constraints
         :assert_no_direct_shipments,
         :assert_no_exclusion_cost,
-        :assert_no_setup_duration,
+        :assert_no_complex_setup_durations,
         :assert_missions_no_late_multiplier,
         :assert_only_one_visit,
 

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -45,7 +45,6 @@ module Wrappers
         :assert_no_subtours,
         :assert_points_same_definition,
         :assert_single_dimension,
-        :assert_not_a_split_solve_candidate,
 
         # Vehicle/route constraints
         :assert_homogeneous_router_definitions,
@@ -76,7 +75,7 @@ module Wrappers
 
     def solve_synchronous?(vrp)
       compatible_routers = %i[car truck_medium]
-      vrp.points.size < 200 && vrp.vehicles.all?{ |vehicle| compatible_routers.include?(vehicle.router_mode&.to_sym) } # WARNING: this should change accordingly with router evolution
+      vrp.points.size < 200 && !Interpreters::SplitClustering.split_solve_candidate?({ vrp: vrp }) && vrp.vehicles.all?{ |vehicle| compatible_routers.include?(vehicle.router_mode&.to_sym) } # WARNING: this should change accordingly with router evolution
     end
 
     def solve(vrp, job = nil, _thread_proc = nil)

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -239,7 +239,7 @@ module Wrappers
     end
 
     def collect_skills(object, vrp_skills)
-      return unless vrp_skills.any?
+      return [] unless vrp_skills.any?
 
       [vrp_skills.size] +
         if object.is_a?(Models::Vehicle)
@@ -309,8 +309,7 @@ module Wrappers
           @total_quantities[unit.id] += value
           (value * CUSTOM_QUANTITY_BIGNUM).round
         },
-        skills: [vrp_skills.size] + activity_objects.first.skills.flat_map{ |skill| vrp_skills.find_index{ |sk| sk == skill } }.compact + # undefined skills are ignored
-          activity_objects.first.sticky_vehicles.flat_map{ |sticky| vrp_skills.find_index{ |sk| sk == sticky.id } }.compact,
+        skills: collect_skills(activity_objects.first, vrp_skills) | collect_skills(activity_objects.last, vrp_skills),
         priority: (100 * (8 - activity_objects.first.priority).to_f / 8).to_i,
         pickup: {
           id: pickup_index,

--- a/wrappers/vroom.rb
+++ b/wrappers/vroom.rb
@@ -41,7 +41,7 @@ module Wrappers
         :assert_correctness_matrices_vehicles_and_points_definition,
         :assert_no_evaluation,
         :assert_no_partitions,
-        :assert_no_relations,
+        :assert_no_relations_except_simple_shipments,
         :assert_no_subtours,
         :assert_points_same_definition,
         :assert_single_dimension,
@@ -149,10 +149,8 @@ module Wrappers
 
     def read_step(vrp, vehicle, step)
       case step['type']
-      when 'job'
-        read_job(vrp, vehicle, step)
-      when 'pickup', 'delivery'
-        read_shipment(vrp, vehicle, step)
+      when 'job', 'pickup', 'delivery'
+        read_activity(vrp, vehicle, step)
       when 'start', 'end'
         read_depot(vrp, vehicle, step)
       when 'break'
@@ -163,12 +161,7 @@ module Wrappers
     end
 
     def read_unassigned(vrp, step)
-      id = step['id']
-      if id < vrp.services.size
-        read_job(vrp, nil, step)
-      else
-        read_shipment(vrp, nil, step)
-      end
+      read_activity(vrp, nil, step)
     end
 
     def read_break(step)
@@ -198,43 +191,39 @@ module Wrappers
       }.merge(route_data).delete_if{ |_k, v| v.nil? }
     end
 
-    def read_job(vrp, vehicle, step)
-      service = vrp.services[step['id']]
-      point = service.activity.point
-      route_data = compute_route_data(vrp, point, step)
-      begin_time = step['arrival'] && (step['arrival'] + step['waiting_time'])
-      job_data = {
-        original_service_id: service.original_id,
-        service_id: service.id,
-        type: 'service',
-        point_id: point.id,
-        begin_time: begin_time,
-        end_time: begin_time && (begin_time + step['service']),
-        departure_time: begin_time && (begin_time + step['service']),
-        detail: build_detail(service, service.activity, point, nil, nil, vehicle)
-      }.merge(route_data).delete_if{ |_k, v| v.nil? }
-      @previous = point
-      job_data
-    end
-
-    def read_shipment(vrp, vehicle, step)
-      shipment = vrp.shipments[((step['id'] - vrp.services.size) / 2).floor]
-      type = ((step['id'] - vrp.services.size) % 2).zero? ? 'pickup' : 'delivery'
-      activity = type == 'pickup' ? shipment.pickup : shipment.delivery
+    def read_activity(vrp, vehicle, step)
+      # activity_object can be a model:shipment, a unitary service or a service in shipment relation (with another)
+      # and in the latter case note that step['type'](pickup/shipment) is not equal to type(service)
+      # which is the case for or-tools as well -- i.e., services appear as services even if they appear
+      # in a shipment relation
+      activity_object, type = @object_id_map[step['id']]
+      activity =
+        case type
+        when :service
+          activity_object.activity
+        when :pickup
+          activity_object.pickup
+        when :delivery
+          activity_object.delivery
+        else
+          raise 'Unimplemented activity type in wrappers/vroom.rb'
+        end
       point = activity.point
       route_data = compute_route_data(vrp, point, step)
       begin_time = step['arrival'] && (step['arrival'] + step['waiting_time'])
       job_data = {
-        original_shipment_id: shipment.original_id,
-        pickup_shipment_id: type == 'pickup' && shipment.id,
-        delivery_shipment_id: type == 'delivery' && shipment.id,
+        original_service_id: type == :service && activity_object.original_id,
+        service_id: type == :service && activity_object.id,
+        original_shipment_id: type != :service && activity_object.original_id,
+        pickup_shipment_id: type == :pickup && activity_object.id,
+        delivery_shipment_id: type == :delivery && activity_object.id,
         type: type,
         point_id: point.id,
         begin_time: begin_time,
         end_time: begin_time && (begin_time + step['service']),
         departure_time: begin_time && (begin_time + step['service']),
-        detail: build_detail(shipment, activity, point, nil, nil, vehicle)
-      }.merge(route_data).delete_if{ |_k, v| v.nil? || v == false }
+        detail: build_detail(activity_object, activity, point, nil, nil, vehicle)
+      }.merge(route_data).delete_if{ |_k, v| v.nil? }
       @previous = point
       job_data
     end
@@ -263,8 +252,12 @@ module Wrappers
     end
 
     def collect_jobs(vrp, vrp_skills, vrp_units)
-      vrp.services.map.with_index{ |service, index|
+      @object_id_map ||= {}
+      # ignore the services with a shipment relation
+      vrp.services.select{ |s| s.relations.none?{ |r| r.type == :shipment } }.map{ |service|
         # Activity is mandatory
+        index = @object_id_map.size
+        @object_id_map[index] = [service, :service]
         {
           id: index,
           location_index: service.activity.point.matrix_index,
@@ -289,30 +282,50 @@ module Wrappers
     end
 
     def collect_shipments(vrp, vrp_skills, vrp_units)
-      vrp.shipments.map.with_index{ |shipment, index|
-        {
-          amount: vrp_units.map{ |unit|
-            value = shipment.quantities.find{ |quantity| quantity.unit.id == unit.id }&.value.to_f.abs
-            @total_quantities[unit.id] += value
-            (value * CUSTOM_QUANTITY_BIGNUM).round
-          },
-          skills: collect_skills(shipment, vrp_skills),
-          priority: (100 * (8 - shipment.priority).to_f / 8).to_i,
-          pickup: {
-            id: vrp.services.size + index * 2,
-            service: shipment.pickup.duration,
-            location_index: shipment.pickup.point.matrix_index,
-            time_windows: shipment.pickup.timewindows.map{ |timewindow| [timewindow.start, timewindow.end || 2**30] }
-          }.delete_if{ |_k, v| v.nil? || v.is_a?(Array) && v.empty? },
-          delivery: {
-            id: vrp.services.size + index * 2 + 1,
-            service: shipment.delivery.duration,
-            location_index: shipment.delivery.point.matrix_index,
-            time_windows: shipment.delivery.timewindows.map{ |timewindow| [timewindow.start, timewindow.end || 2**30] }
-          }.delete_if{ |_k, v| v.nil? || v.is_a?(Array) && v.empty? }
-        }.delete_if{ |_k, v|
-          v.nil? || v.is_a?(Array) && v.empty?
-        }
+      vrp.relations.select{ |r| r.type == :shipment }.map{ |relation|
+        pickup, delivery = relation.linked_services
+        collect_shipments_core([pickup, delivery], [pickup.activity, delivery.activity], [:service], vrp_skills, vrp_units)
+      } + vrp.shipments.map{ |shipment|
+        collect_shipments_core([shipment], [shipment.pickup, shipment.delivery], [:pickup, :delivery], vrp_skills, vrp_units)
+      }
+    end
+
+    def collect_shipments_core(activity_objects, activities, types, vrp_skills, vrp_units)
+      @object_id_map ||= {}
+      # handles both services in shipment relation and model:shipments
+      # activity_objects [array] contains the two services (pickup and delivery) or the shipment
+      # activities [array] contains the model:activity of the services (pickup.activity, delivery.activity) or the shipment (shipment.pickup, shipment.delivery)
+      # types [array] contains the type of the objects -- i.e., [:service, :service] for services in shipment relation or [:pickup, :delivery] for model:shipment
+      pickup_index = @object_id_map.size
+      delivery_index = pickup_index + 1
+
+      @object_id_map[pickup_index] = [activity_objects.first, types.first]
+      @object_id_map[delivery_index] = [activity_objects.last, types.last]
+
+      pickup, delivery = activities.first, activities.last
+      {
+        amount: vrp_units.map{ |unit|
+          value = activity_objects.first.quantities.find{ |quantity| quantity.unit.id == unit.id }&.value.to_f.abs
+          @total_quantities[unit.id] += value
+          (value * CUSTOM_QUANTITY_BIGNUM).round
+        },
+        skills: [vrp_skills.size] + activity_objects.first.skills.flat_map{ |skill| vrp_skills.find_index{ |sk| sk == skill } }.compact + # undefined skills are ignored
+          activity_objects.first.sticky_vehicles.flat_map{ |sticky| vrp_skills.find_index{ |sk| sk == sticky.id } }.compact,
+        priority: (100 * (8 - activity_objects.first.priority).to_f / 8).to_i,
+        pickup: {
+          id: pickup_index,
+          service: pickup.duration,
+          location_index: pickup.point.matrix_index,
+          time_windows: pickup.timewindows.map{ |timewindow| [timewindow.start, timewindow.end || 2**30] }
+        }.delete_if{ |_k, v| v.nil? || v.is_a?(Array) && v.empty? },
+        delivery: {
+          id: delivery_index,
+          service: delivery.duration,
+          location_index: delivery.point.matrix_index,
+          time_windows: delivery.timewindows.map{ |timewindow| [timewindow.start, timewindow.end || 2**30] }
+        }.delete_if{ |_k, v| v.nil? || v.is_a?(Array) && v.empty? }
+      }.delete_if{ |_k, v|
+        v.nil? || v.is_a?(Array) && v.empty?
       }
     end
 

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -43,19 +43,19 @@ module Wrappers
     end
 
     def assert_vehicles_start(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?{ |vehicle|
+      vrp.vehicles.none?{ |vehicle|
         vehicle.start_point.nil?
       }
     end
 
     def assert_vehicles_start_or_end(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?{ |vehicle|
+      vrp.vehicles.none?{ |vehicle|
         vehicle.start_point.nil? && vehicle.end_point.nil?
       }
     end
 
     def assert_vehicles_no_capacity_initial(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?{ |vehicle|
+      vrp.vehicles.none?{ |vehicle|
         vehicle.capacities.find{ |c| c.initial&.positive? }
       }
     end
@@ -65,11 +65,11 @@ module Wrappers
     end
 
     def assert_no_direct_shipments(vrp)
-      vrp.shipments.none?{ |shipment| shipment.direct }
+      vrp.shipments.none?(&:direct)
     end
 
     def assert_no_pickup_timewindows_after_delivery_timewindows(vrp)
-      vrp.shipments.empty? || vrp.shipments.none? { |shipment|
+      vrp.shipments.none? { |shipment|
         first_open = shipment.pickup.timewindows.min_by(&:start)
         last_close = shipment.delivery.timewindows.max_by(&:end)
         first_open && last_close && first_open.start + 86400 * (first_open.day_index || 0) >
@@ -78,7 +78,7 @@ module Wrappers
     end
 
     def assert_services_no_priority(vrp)
-      vrp.services.empty? || vrp.services.uniq(&:priority).size == 1
+      vrp.services.uniq(&:priority).size <= 1
     end
 
     def assert_vehicles_objective(vrp)
@@ -91,7 +91,7 @@ module Wrappers
     end
 
     def assert_vehicles_no_late_multiplier(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?{ |vehicle|
+      vrp.vehicles.none?{ |vehicle|
         vehicle.cost_late_multiplier&.positive?
       }
     end
@@ -101,7 +101,7 @@ module Wrappers
     end
 
     def assert_vehicles_no_overload_multiplier(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?{ |vehicle|
+      vrp.vehicles.none?{ |vehicle|
         vehicle.capacities.find{ |capacity|
           capacity.overload_multiplier&.positive?
         }
@@ -109,21 +109,21 @@ module Wrappers
     end
 
     def assert_vehicles_no_force_start(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?(&:force_start)
+      vrp.vehicles.none?(&:force_start)
     end
 
     def assert_vehicles_no_duration_limit(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?(&:duration)
+      vrp.vehicles.none?(&:duration)
     end
 
     def assert_vehicles_no_zero_duration(vrp)
-      vrp.vehicles.empty? || vrp.vehicles.none?{ |vehicle|
+      vrp.vehicles.none?{ |vehicle|
         vehicle.duration&.zero?
       }
     end
 
     def assert_services_no_late_multiplier(vrp)
-      vrp.services.empty? || vrp.services.none?{ |service|
+      vrp.services.none?{ |service|
         if service.activity
           service.activity&.timewindows&.size&.positive? && service.activity&.late_multiplier&.positive?
         else
@@ -135,7 +135,7 @@ module Wrappers
     end
 
     def assert_shipments_no_late_multiplier(vrp)
-      vrp.shipments.empty? || vrp.shipments.none?{ |shipment|
+      vrp.shipments.none?{ |shipment|
         shipment.pickup.late_multiplier&.positive? || shipment.delivery.late_multiplier&.positive?
       }
     end
@@ -167,11 +167,8 @@ module Wrappers
     end
 
     def assert_one_sticky_at_most(vrp)
-      (vrp.services.empty? || vrp.services.none?{ |service|
-        service.sticky_vehicles.size > 1
-      }) && (vrp.shipments.empty? || vrp.shipments.none?{ |shipment|
-        shipment.sticky_vehicles.size > 1
-      })
+      vrp.services.none?{ |service| service.sticky_vehicles.size > 1 } &&
+        vrp.shipments.none?{ |shipment| shipment.sticky_vehicles.size > 1 }
     end
 
     def assert_no_relations(vrp)

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -450,10 +450,6 @@ module Wrappers
         }
     end
 
-    def assert_not_a_split_solve_candidate(vrp)
-      !Interpreters::SplitClustering.split_solve_candidate?({ vrp: vrp })
-    end
-
     def solve_synchronous?(_vrp)
       false
     end

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -171,8 +171,10 @@ module Wrappers
         vrp.shipments.none?{ |shipment| shipment.sticky_vehicles.size > 1 }
     end
 
-    def assert_no_relations(vrp)
-      vrp.relations.empty? || vrp.relations.all?{ |relation| relation.linked_ids.empty? && relation.linked_vehicle_ids.empty? }
+    def assert_no_relations_except_simple_shipments(vrp)
+      vrp.relations.all?{ |r|
+        (r.type == :shipment && r.linked_ids.size == 2) ||
+          (r.linked_ids.empty? && r.linked_vehicle_ids.empty?) }
     end
 
     def assert_zones_only_size_one_alternative(vrp)


### PR DESCRIPTION
- collect_data_items respects the minimum vehicle limits
- linking_relations can be grouped in collect_items
- split_solve represents services w multiple points
- Vroom can handle simplified setup durations
- Vroom can handle shipments as relation
- max_split_size prevents only optim-sync and Vroom can be called for sub-rpoblems
- small quality and linter fixes