### PR TITLE
Tests cleaning in periodic tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -178,7 +178,6 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
             matrices =
               OptimizerWrapper.router.send(:__minitest_stub__matrix, url, mode, dimensions, row, column, options) # call original method
             WebMock.disable_net_connect!
-
             write_in_dump <<
               { url: url, mode: mode, dimensions: dimensions, row: row, column: column, options: options, matrices: matrices }
             matrices
@@ -187,8 +186,8 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
               request[:mode] == mode && request[:dimensions] == dimensions &&
                 request[:options] == options &&
                 # Oj rounds values :
-                request[:row] == row.collect{ |r| r.collect{ |v| v.round(6) } } &&
-                request[:column] == column.collect{ |c| c.collect{ |v| v.round(6) } }
+                request[:row].collect{ |r| r.collect{ |v| v.round(6) } } == row.collect{ |r| r.collect{ |v| v.round(6) } } &&
+                request[:column].collect{ |c| c.collect{ |v| v.round(6) } } == column.collect{ |c| c.collect{ |v| v.round(6) } }
             }
             raise 'Could not find matrix in the dump' unless corresponding_data
 

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3265,4 +3265,15 @@ class WrapperTest < Minitest::Test
     unfeasible_services = OptimizerWrapper.config[:services][:demo].detect_unfeasible_services(TestHelper.create(vrp))
     assert_equal 1, (unfeasible_services.count{ |un| un[:reason] == 'Service timewindows are infeasible' })
   end
+
+  def test_multiple_reason
+    problem = VRP.lat_lon_periodic
+    problem[:services][5][:activity][:duration] = 28000
+    problem[:services][5][:quantities] = [{ unit_id: 'kg', value: 5000 }]
+    problem[:vehicles].first[:timewindow] = { start: 0, end: 24500 }
+    problem[:vehicles].first[:capacities] = [{ unit_id: 'kg', limit: 1100 }]
+
+    result = OptimizerWrapper.wrapper_vrp('demo', { services: { vrp: [:demo] }}, TestHelper.load_vrp(self, problem: problem), nil)
+    assert(result[:unassigned].collect{ |una| una[:reason].include?('&&') })
+  end
 end


### PR DESCRIPTION
One test was useless : it checked number of visits when no vehicle is provided but this is already checked within optimizer_wrapper.rb now. Also, it checked returned number of rests when no services are provided in periodic_heuristic, but rests are not allowed in periodic so this is not consistent.

Most of modified tests where just too long : we now have exactly same verifications, but with minimal changes in vrp.

One tests was in wrong file.

This will help debug failing tests from now on.