### PR TITLE
Move ci to one build

### DIFF
--- a/.github/actions/launch_stack.sh
+++ b/.github/actions/launch_stack.sh
@@ -1,30 +1,23 @@
 #!/usr/bin/env bash
 
-docker build --build-arg BUNDLE_WITHOUT=development --build-arg VROOM_VERSION=${VROOM_VERSION} --build-arg OPTIMIZER_ORTOOLS_VERSION=${OPTIMIZER_ORTOOLS_VERSION} -f docker/Dockerfile -t registry.test.com/mapotempo/optimizer-api:latest .
-
-# Cache generated gems
-mkdir -p vendor/bundle
-docker cp $(docker create --rm registry.test.com/mapotempo/optimizer-api:latest):/srv/app/vendor/bundle/. vendor/bundle
-
 # Initialize swarm
 docker swarm init
 mkdir -p ./redis
 mkdir -p ./redis-count
-docker stack deploy -c ./docker/docker-compose.yml ${PROJECT}
+docker stack deploy -c ./docker/docker-compose.yml "${PROJECT}"
 
 # Wait until all services are up
-REGISTRY=${REGISTRY:-registry.mapotempo.com}
 max_time=60 # Time in secondes
-for ((cpt=1;cpt<=$max_time;cpt++));
+for ((cpt=1;cpt<=max_time;cpt++));
 do
-  if [ $cpt == ${max_time} ];
+  if [ "${cpt}" == ${max_time} ];
   then
     echo "Could not start services after ${max_time} seconds"
     docker service ls
     for srv in $(docker service ls | grep 0/1 | awk '{print $1}');
     do
-      docker service ps --no-trunc $srv
-      docker service logs $srv
+      docker service ps --no-trunc "$srv"
+      docker service logs "$srv"
     done
     exit 1
   fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,30 +3,66 @@ name: Docker Image CI
 on:
   push:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   NB_SERVICES: ${{ secrets.NB_SERVICES }}
-  OPTIMIZER_ORTOOLS_VERSION: ${{ secrets.OPTIMIZER_ORTOOLS_VERSION }}
   PROJECT: optimizer
-  REGISTRY: ${{ secrets.REGISTRY }}
-  VROOM_VERSION: ${{ secrets.VROOM_VERSION }}
 
 jobs:
-  test_basis:
+  build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    env:
-      OPTIONS: "COV=false LOG_LEVEL=info SKIP_DICHO=true SKIP_REAL_CASES=true SKIP_PERIODIC=true SKIP_SPLIT_CLUSTERING=true"
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Cache
         id: cache
         uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ${{ runner.os }}
-      - name: Build image
-        run: ./.github/actions/build.sh
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: |
+            BUNDLE_WITHOUT=production
+            OPTIMIZER_ORTOOLS_VERSION=${{ secrets.OPTIMIZER_ORTOOLS_VERSION }}
+            VROOM_VERSION=${{ secrets.VROOM_VERSION }}
+          tags: registry.test.com/mapotempo/optimizer-api:latest
+          outputs: type=docker,dest=/tmp/optimizer-api.tar
+      - name: Extract gems from image to cache folder
+        run: |
+          mkdir -p vendor/bundle
+          docker load --input /tmp/optimizer-api.tar
+          docker cp "$(docker create --rm registry.test.com/mapotempo/optimizer-api:latest)":/srv/app/vendor/bundle/. vendor/bundle
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: /tmp/optimizer-api.tar
+
+  test_basis:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      OPTIONS: "COV=false LOG_LEVEL=info SKIP_DICHO=true SKIP_REAL_CASES=true SKIP_PERIODIC=true SKIP_SPLIT_CLUSTERING=true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
         shell: bash
       - name: Starting tests
         timeout-minutes: 10
@@ -34,19 +70,23 @@ jobs:
         shell: bash
 
   test_dicho:
+    needs: build
     runs-on: ubuntu-latest
     env:
       OPTIONS: "COV=false LOG_LEVEL=info TEST=test/lib/heuristics/dichotomious_test.rb"
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache
-        id: cache
-        uses: actions/cache@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
         with:
-          path: vendor/bundle
-          key: ${{ runner.os }}
-      - name: Build image
-        run: ./.github/actions/build.sh
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
         shell: bash
       - name: Starting tests
         timeout-minutes: 20
@@ -54,19 +94,23 @@ jobs:
         shell: bash
 
   test_real:
+    needs: build
     runs-on: ubuntu-latest
     env:
       OPTIONS: "COV=false LOG_LEVEL=info TEST=test/real_cases_test.rb"
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache
-        id: cache
-        uses: actions/cache@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
         with:
-          path: vendor/bundle
-          key: ${{ runner.os }}
-      - name: Build image
-        run: ./.github/actions/build.sh
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
         shell: bash
       - name: Starting tests
         timeout-minutes: 10
@@ -74,81 +118,97 @@ jobs:
         shell: bash
 
   test_real_periodic:
-      runs-on: ubuntu-latest
-      env:
-        OPTIONS: "COV=false LOG_LEVEL=info TEST=test/real_cases_periodic_test.rb"
-      steps:
-        - uses: actions/checkout@v2
-        - name: Cache
-          id: cache
-          uses: actions/cache@v2
-          with:
-            path: vendor/bundle
-            key: ${{ runner.os }}
-        - name: Build image
-          run: ./.github/actions/build.sh
-          shell: bash
-        - name: Starting tests
-          timeout-minutes: 30
-          run: ./.github/actions/tests.sh
-          shell: bash
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      OPTIONS: "COV=false LOG_LEVEL=info TEST=test/real_cases_periodic_test.rb"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
+        shell: bash
+      - name: Starting tests
+        timeout-minutes: 30
+        run: ./.github/actions/tests.sh
+        shell: bash
 
   test_real_periodic_solver:
-      runs-on: ubuntu-latest
-      env:
-        OPTIONS: "COV=false LOG_LEVEL=info TEST=test/real_cases_periodic_solver_test.rb"
-      steps:
-        - uses: actions/checkout@v2
-        - name: Cache
-          id: cache
-          uses: actions/cache@v2
-          with:
-            path: vendor/bundle
-            key: ${{ runner.os }}
-        - name: Build image
-          run: ./.github/actions/build.sh
-          shell: bash
-        - name: Starting tests
-          timeout-minutes: 20
-          run: ./.github/actions/tests.sh
-          shell: bash
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      OPTIONS: "COV=false LOG_LEVEL=info TEST=test/real_cases_periodic_solver_test.rb"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
+        shell: bash
+      - name: Starting tests
+        timeout-minutes: 20
+        run: ./.github/actions/tests.sh
+        shell: bash
 
   test_periodic:
-      runs-on: ubuntu-latest
-      env:
-        OPTIONS: "COV=false LOG_LEVEL=info TEST=test/lib/heuristics/periodic_*"
-      steps:
-        - uses: actions/checkout@v2
-        - name: Cache
-          id: cache
-          uses: actions/cache@v2
-          with:
-            path: vendor/bundle
-            key: ${{ runner.os }}
-        - name: Build image
-          run: ./.github/actions/build.sh
-          shell: bash
-        - name: Starting tests
-          timeout-minutes: 5
-          run: ./.github/actions/tests.sh
-          shell: bash
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      OPTIONS: "COV=false LOG_LEVEL=info TEST=test/lib/heuristics/periodic_*"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
+        shell: bash
+      - name: Starting tests
+        timeout-minutes: 5
+        run: ./.github/actions/tests.sh
+        shell: bash
 
   test_split_clustering:
-      runs-on: ubuntu-latest
-      env:
-        OPTIONS: "COV=false LOG_LEVEL=info TEST=test/lib/interpreters/split_clustering_test.rb"
-      steps:
-        - uses: actions/checkout@v2
-        - name: Cache
-          id: cache
-          uses: actions/cache@v2
-          with:
-            path: vendor/bundle
-            key: ${{ runner.os }}
-        - name: Build image
-          run: ./.github/actions/build.sh
-          shell: bash
-        - name: Starting tests
-          timeout-minutes: 25
-          run: ./.github/actions/tests.sh
-          shell: bash
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      OPTIONS: "COV=false LOG_LEVEL=info TEST=test/lib/interpreters/split_clustering_test.rb"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp
+      - name: Load Docker image
+        run: docker load --input /tmp/artifact/optimizer-api.tar
+      - name: Launch Stack
+        run: ./.github/actions/launch_stack.sh
+        shell: bash
+      - name: Starting tests
+        timeout-minutes: 25
+        run: ./.github/actions/tests.sh
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache
+      - name: Cache layers and gems
         id: cache
         uses: actions/cache@v2
         with:
-          path: vendor/bundle
-          key: ${{ runner.os }}
+          path: |
+            vendor/bundle
+            /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ hashFiles('Gemfile.lock') }}
+      - name: Check cached gems
+        run: |
+          echo $(pwd)
+          echo $(ls -lh vendor/bundle)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build
@@ -35,11 +41,19 @@ jobs:
             VROOM_VERSION=${{ secrets.VROOM_VERSION }}
           tags: registry.test.com/mapotempo/optimizer-api:latest
           outputs: type=docker,dest=/tmp/optimizer-api.tar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+      - name: Move buildx cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Extract gems from image to cache folder
         run: |
+          rm -rf vendor/bundle
           mkdir -p vendor/bundle
           docker load --input /tmp/optimizer-api.tar
           docker cp "$(docker create --rm registry.test.com/mapotempo/optimizer-api:latest)":/srv/app/vendor/bundle/. vendor/bundle
+          echo $(ls -lh vendor/bundle)
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Mapotempo/active_hash.git
-  revision: 6471576562e2db78fa87f8a1cc6ec848c88ab76e
+  revision: e2b18fedb32aec0cc03f0c747dbc682cbb8fc488
   branch: mapo
   specs:
     active_hash (3.1.0)
@@ -63,7 +63,7 @@ GEM
     charlock_holmes (0.7.7)
     chunky_png (1.4.0)
     color-generator (0.0.4)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -120,7 +120,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.8.5)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     litecable (0.7.0)
@@ -135,7 +135,7 @@ GEM
     mime-types-data (3.2020.0512)
     mini_portile2 (2.5.2)
       net-ftp (~> 0.1)
-    minitest (5.14.2)
+    minitest (5.14.4)
     minitest-around (0.5.0)
       minitest (~> 5.0)
     minitest-bisect (1.5.1)
@@ -272,7 +272,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     time (0.1.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -286,7 +286,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.8)
     yard (0.9.25)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.2)
     zlib (1.0.0)
 
 PLATFORMS

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y git libgeos-dev ${libgeos} libicu-dev nano > /dev/null
 
 COPY . /srv/app
 WORKDIR /srv/app
-RUN gem install bundler --version 2.1.4
+RUN gem install bundler --version 2.2.16
 RUN bundle --version
 RUN bundle install --path vendor/bundle --full-index --without ${BUNDLE_WITHOUT} -j $(nproc)
 


### PR DESCRIPTION
Since the docker build can take a lot of time because of writing on the disk, Halil proposed to build once and use artifact to get the image and launch tests. As the new *docker/build-push-action@v2* allows to store image in artifact, this PR uses it.

To limit the number of pipelines, I changed the workflow. It won't launch pipelines on Draft PR. This PR also uses layer caching.