### PR TITLE
Add test against ignored TWs & bump optimizer-ortools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - VROOM was used incorrectly in various cases: negative quantities, vehicle duration, activity position [#223](https://github.com/Mapotempo/optimizer-api/pull/223) [#242](https://github.com/Mapotempo/optimizer-api/pull/242)
 - Capacity violation in periodic heuristic algorithm (`first_solution_strategy='periodic'`) [#227](https://github.com/Mapotempo/optimizer-api/pull/227)
+- Service timewindows without an `end` were not respected [#262](https://github.com/Mapotempo/optimizer-api/pull/262)
 
 ## [v1.7.1] - 2021-05-20
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ bundle install
 
 This project requires some solver and interface projects in order to be fully functionnal!
 * [Vroom v1.8.0](https://github.com/VROOM-Project/vroom/releases/tag/v1.8.0)
-* [Optimizer-ortools v1.5.0](https://github.com/Mapotempo/optimizer-ortools) & [OR-Tools v7.8](https://github.com/google/or-tools/releases/tag/v7.8) (use the version corresponding to your system operator, not source code).
+* [Optimizer-ortools v1.6.0](https://github.com/Mapotempo/optimizer-ortools) & [OR-Tools v7.8](https://github.com/google/or-tools/releases/tag/v7.8) (use the version corresponding to your system operator, not source code).
 
 Note : when updating OR-Tools you should to recompile optimizer-ortools.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG BUNDLE_WITHOUT="development test"
 FROM vroomvrp/vroom-docker:${VROOM_VERSION:-v1.8.0} as vroom
 
 # Rake
-FROM ${REGISTRY}mapotempo-${BRANCH}/optimizer-ortools:${OPTIMIZER_ORTOOLS_VERSION:-v1.5.0}
+FROM ${REGISTRY}mapotempo-${BRANCH}/optimizer-ortools:${OPTIMIZER_ORTOOLS_VERSION:-v1.6.0}
 ARG BUNDLE_WITHOUT
 
 ENV LANG C.UTF-8

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -264,6 +264,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
       configuration: {
         resolution: {
           duration: 100
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }
@@ -319,7 +322,10 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
         resolution: {
           duration: 100
         },
-        preprocessing: {}
+        preprocessing: {},
+        restitution: {
+          intermediate_solutions: false,
+        }
       }
     }
   end
@@ -498,7 +504,10 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
         resolution: {
           duration: 2000
         },
-        preprocessing: {}
+        preprocessing: {},
+        restitution: {
+          intermediate_solutions: false,
+        }
       }
     }
   end
@@ -616,7 +625,10 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
         resolution: {
           duration: 2000
         },
-        preprocessing: {}
+        preprocessing: {},
+        restitution: {
+          intermediate_solutions: false,
+        }
       }
     }
   end
@@ -683,6 +695,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
             start: 0,
             end: 3
           }
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }
@@ -818,6 +833,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
       configuration: {
         resolution: {
           duration: 100
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }
@@ -853,6 +871,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
           start: 0,
           end: 3
         }
+      },
+      restitution: {
+        intermediate_solutions: false,
       }
     }
 
@@ -1052,6 +1073,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
       configuration: {
         resolution: {
           duration: 100
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }
@@ -1184,6 +1208,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
             start: 0,
             end: 10
           }
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }
@@ -1294,6 +1321,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
       configuration: {
         resolution: {
           duration: 100
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }
@@ -1391,6 +1421,9 @@ module VRP # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
       configuration: {
         resolution: {
           duration: 100
+        },
+        restitution: {
+          intermediate_solutions: false,
         }
       }
     }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -139,6 +139,15 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
       v[:skills].each{ |set| set.map!(&:to_sym) }
     }
 
+    # trips parameter does not exist anymore
+    vrp[:vehicles]&.each{ |v|
+      next unless v[:trips]
+
+      raise 'vehicle[:trips] parameter does not exist' if v[:trips] > 1
+
+      v.delete(:trips)
+    }
+
     vrp
   end
 


### PR DESCRIPTION
It adds a tests against time-windows without an `end` getting ignored and bumps the opmizer-ortools version to the one with the fix.

- [ ] Needs https://github.com/Mapotempo/optimizer-ortools/pull/25 to be merged and tagged `v1.6.0` on the optimizer-ortools repo
- [ ] Relaunch the CI after the merge&tag to test optim-ortools integration