### PR TITLE
Improve performance of first/last_possible_days check

### DIFF
--- a/test/lib/heuristics/periodic_functions_test.rb
+++ b/test/lib/heuristics/periodic_functions_test.rb
@@ -668,23 +668,5 @@ class HeuristicTest < Minitest::Test
       assert s.send(:day_in_possible_interval, 'service_1', 1) # this case will be avoided by compute days
       refute s.send(:compatible_days, 'service_1', 1)
     end
-
-    def test_can_find_a_distinct_array_per_set_function
-      vrp = TestHelper.create(VRP.periodic)
-      vrp.vehicles = TestHelper.expand_vehicles(vrp)
-      s = Wrappers::PeriodicHeuristic.new(vrp)
-
-      assert s.send(:can_find_a_distinct_array_per_set, [[[0, 4], [2, 3]], [[0, 4], [2, 3]]])
-      refute s.send(:can_find_a_distinct_array_per_set, [[[0, 4], [2, 3]], [[0, 4], [2, 3]], [[0, 4], [2, 3]]])
-      assert s.send(:can_find_a_distinct_array_per_set, [[[1, 2]], [[3, 4]], [[5, 6]]])
-      assert s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4]], [[1, 2], [5, 6]], [[1, 2]]])
-      refute s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4], [5, 6]], [[1, 2]], [[3, 4]], [[5, 6]]])
-      assert s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4], [5, 6], [7, 8]], [[1, 2]], [[3, 4]], [[5, 6]]])
-      assert s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4], [5, 6], [7, 8]], [[1, 2], [7, 8]], [[3, 4]], [[5, 6]]])
-      refute s.send(:can_find_a_distinct_array_per_set, [[[1, 2]], [[1, 2]], [[3, 4]]])
-      assert s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]], [[3, 4], [5, 6]]])
-      refute s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]], [[3, 4], [5, 6]], [[3, 4], [5, 6]]])
-      assert s.send(:can_find_a_distinct_array_per_set, [[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4]], [[3, 4], [7, 8], [9, 10]], [[3, 4], [7, 8], [9, 10]]])
-    end
   end
 end


### PR DESCRIPTION
Apparently there was a better way to do this. 

Corrects the performance problem we found : 
- for a given instance we used ~3 to 4 seconds to solve before implementing first/last_possible_days check
- we needed ~10 seconds after implementing it (which correspond to 16 seconds on beta server)

This edit allows to solve this VRP in ~ 5 seconds. We do increase computation time little but we are make lot of additional checks in order to respect new provided constraints so this is consistent for me.