### PR TITLE
Fix missing partition skills breaks geojson parsing

### DIFF
--- a/lib/interpreters/split_clustering.rb
+++ b/lib/interpreters/split_clustering.rb
@@ -1356,6 +1356,7 @@ module Interpreters
             service.skills.insert(0, "vehicle_partition_#{vrp.vehicles.first.id}".to_sym)
           }
           vrp.vehicles.each{ |v|
+            # assumes vehicle.skills is an array of arrays
             v.skills.each{ |set| set << "vehicle_partition_#{vrp.vehicles.first.id}".to_sym }
           }
         when :work_day

--- a/test/api/v01/output_test.rb
+++ b/test/api/v01/output_test.rb
@@ -520,19 +520,21 @@ class Api::V01::OutputTest < Minitest::Test
 
     legacy_basic_headers = %w[vehicle_id id point_id type begin_time end_time setup_duration duration skills]
     french_basic_headers = ['tournée', 'référence', 'heure', 'fin de la mission', 'durée client', 'durée visite', 'libellés']
-    [[true, legacy_basic_headers],
-     [false, french_basic_headers]].each{ |parameter, expected|
 
-      vrp[:configuration][:restitution][:use_deprecated_csv_headers] = parameter
+    asynchronously start_worker: true do
+      [
+        [true, legacy_basic_headers],
+        [false, french_basic_headers]
+      ].each{ |parameter, expected|
+        vrp[:configuration][:restitution][:use_deprecated_csv_headers] = parameter
 
-      asynchronously start_worker: true do
         @job_id = submit_csv api_key: 'demo', vrp: vrp, http_accept_language: 'fr'
         wait_status_csv @job_id, 200, api_key: 'demo', http_accept_language: 'fr'
         current_headers = last_response.body.split("\n").first.split(',')
         assert_empty expected - current_headers
 
-        delete_completed_job @job_id, api_key: 'ortools'
-      end
-    }
+        delete_completed_job @job_id, api_key: 'demo'
+      }
+    end
   end
 end

--- a/test/lib/heuristics/periodic_test.rb
+++ b/test/lib/heuristics/periodic_test.rb
@@ -257,7 +257,7 @@ class HeuristicTest < Minitest::Test
 
       result = OptimizerWrapper.wrapper_vrp('ortools', { services: { vrp: [:ortools] }}, TestHelper.load_vrp(self, problem: problem), nil)
       assert_empty result[:unassigned]
-      assert(result[:routes].all?{ |route| route[:activities].all?{ |activity| activity[:detail][:skills].nil? || activity[:detail][:skills].size == 2 } })
+      assert(result[:routes].all?{ |route| route[:activities].all?{ |activity| activity[:detail][:skills].nil? || activity[:detail][:skills].size == 3 } })
     end
 
     def test_callage_freq

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,7 +57,7 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
     # This function is called both with a JSON and Models::Vrp
     # That is, service[:activity]&.fetch(symbol) do not work
     # Code needs to be valid both for vrp and json.
-    # Thus `if service[:activity] && service[:activity][symbol]` style verificiations.
+    # Thus `if service[:activity] && service[:activity][symbol]` style verifications.
 
     vrp[:points]&.each{ |pt|
       next unless pt[:location]
@@ -79,6 +79,13 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
     }
 
     vrp[:vehicles].each{ |vehicle|
+      if vehicle.key?(:skills)
+        vehicle.delete(:skills) if vehicle[:skills].nil? || vehicle[:skills].empty?
+
+        raise 'Vehicle skills should be an Array[Array[Symbol]]' if vehicle[:skills]&.any?{ |skill_set| !skill_set.is_a? Array }
+
+        vehicle[:skills]&.each{ |skill_set| skill_set.map!(&:to_sym) }
+      end
       vehicle.delete(:original_id)
     }
 


### PR DESCRIPTION
- Even if there is only one cluster, we call `build_partial_service_vrp` instead of doing simple `[Marshal.load(Marshal.dump(service_vrp))]` to correct the skills and sequence_timewindows etc.
- Fix issues related to add_unassigned
- Trying to fix a randomly failing test by launching the worker only once

Closes optimizer-api/-/issues/865