### PR TITLE
Edit cases where vehicles skills are initialized with empty skills

### DIFF
--- a/models/vehicle.rb
+++ b/models/vehicle.rb
@@ -110,7 +110,7 @@ module Models
         hash[:unavailable_days].delete_if{ |index| !work_day_indices.include?(index.modulo(7)) }
       end
 
-      hash[:skills] = [[]] unless hash.has_key?(:skills) # If vehicle has no skills, it has the empty skillset
+      hash[:skills] = [[]] if hash[:skills].to_a.empty? # If vehicle has no skills, it has the empty skillset
 
       super(hash)
     end

--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -237,7 +237,7 @@ module Models
       vrp.add_sticky_vehicle_if_routes_and_partitions
       vrp.expand_unavailable_days
       vrp.provide_original_info
-      vrp.sticky_as_skills
+      vrp.sticky_as_skills # TODO: this should be done on hash in order to completely remove sticky_vehicles from service model
     end
 
     def self.convert_position_relations(hash)


### PR DESCRIPTION
VRPs sent by mapotempo-web send [] as default vehicle skills.

We used to keep this value in whole code.

When we convert sticky_vehicles into skills this produces a problem : https://gitlab.com/mapotempo/optimizer-api/-/issues/869