### PR TITLE
Set Redis read & write timeout manually

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -2,5 +2,9 @@ require 'resque'
 require 'resque-status'
 
 Resque.inline = ENV['APP_ENV'] == 'test'
-Resque.redis = ENV['REDIS_RESQUE_HOST'] || ENV['REDIS_HOST'] || 'localhost'
+Resque.redis = Redis.new(
+  host: ENV['REDIS_RESQUE_HOST'] || ENV['REDIS_HOST'] || 'localhost',
+  read_timeout: 180.0,
+  write_timeout: 180.0
+)
 Resque::Plugins::Status::Hash.expire_in = (30 * 24 * 60 * 60) # In seconds, a too small value remove working or queuing jobs

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -2815,9 +2815,9 @@ class WrapperTest < Minitest::Test
     # corrected/increased. On local, the total_times are almost half the limits.
     # The goal of this test is to prevent adding an involuntary exponential logic and the limits can increase linearly
     # if more verifications are added but the time should not jump orders of magnitude.
-    assert_operator total_check_distances_time, :<=, 2.5, 'check_distances function took longer than expected'
-    assert_operator total_add_unassigned_time, :<=, 5.0, 'add_unassigned function took longer than expected'
-    assert_operator total_detect_unfeasible_services_time, :<=, 7.5, 'detect_unfeasible_services function took too long'
+    assert_operator total_check_distances_time, :<=, 3.0, 'check_distances function took longer than expected'
+    assert_operator total_add_unassigned_time, :<=, 6.0, 'add_unassigned function took longer than expected'
+    assert_operator total_detect_unfeasible_services_time, :<=, 8.0, 'detect_unfeasible_services function took too long'
   ensure
     OptimizerLogger.level = old_logger_level if old_logger_level
     OptimizerWrapper.config[:solve][:repetition] = old_config_solve_repetition if old_config_solve_repetition


### PR DESCRIPTION
with 70% of the data, one client received Redis.timeout error during solution write -- which took in total 1m27s so we set the read & write timeout values to 3 minutes to make sure that solution write operation will not pose a problem 