### PR TITLE
[CI] Fix build error because of passenger-docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,19 @@ ENV LANG C.UTF-8
 # Set correct environment variables.
 ENV HOME /root
 
+# Trick to install passenger-docker on Ruby 2.5. Othwerwise `apt-get update` fails with a
+# certificate error. See following links for explanantion:
+# https://issueexplorer.com/issue/phusion/passenger-docker/325
+# and
+# https://issueexplorer.com/issue/phusion/passenger-docker/322
+# Basically, DST Root CA X3 certificates are expired on Setember 2021 and apt-get cannot validate
+# with the old certificates and the certification correction is only done for Ruby 2.6+ on the
+# passenger-docker repo because Ruby 2.5 is EOL.
+RUN mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak
+RUN apt update && apt install -y ca-certificates
+RUN mv /etc/apt/sources.list.d.bak /etc/apt/sources.list.d
+# The above trick can be removed after Ruby version is increased.
+
 RUN apt-get update > /dev/null
 RUN libgeos=$(apt-cache search 'libgeos-' | grep -P 'libgeos-\d.*' | awk '{print $1}')
 RUN apt-get install -y git libgeos-dev ${libgeos} libicu-dev nano > /dev/null


### PR DESCRIPTION
LetsEncrypt expired the DST Root CA X3 certificates because of this 
apt-get cannotvalidate the certificate of passenger-docker because 
phusion fixed the issue only on Ruby 2.6+ images since Ruby 2.5 is 
end-of-life.