### PR TITLE
Fix #882 violated multi pickup delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ gem install bundler
 bundle install
 ```
 
-This project requires some solver and interface projects in order to be fully functionnal!
+This project requires some solver and interface projects in order to be fully functional!
 * [Vroom v1.8.0](https://github.com/VROOM-Project/vroom/releases/tag/v1.8.0)
-* [Optimizer-ortools v1.9.0](https://github.com/Mapotempo/optimizer-ortools) & [OR-Tools v7.8](https://github.com/google/or-tools/releases/tag/v7.8) (use the version corresponding to your system operator, not source code).
+* [Optimizer-ortools v1.10.0](https://github.com/Mapotempo/optimizer-ortools) & [OR-Tools v7.8](https://github.com/google/or-tools/releases/tag/v7.8) (use the version corresponding to your system operator, not source code).
 
 Note : when updating OR-Tools you should to recompile optimizer-ortools.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG VROOM_VERSION
 FROM vroomvrp/vroom-docker:${VROOM_VERSION:-v1.8.0} as vroom
 
 # Rake
-FROM ${REGISTRY:-registry.mapotempo.com/}mapotempo-${BRANCH:-ce}/optimizer-ortools:${OPTIMIZER_ORTOOLS_VERSION:-v1.9.0}
+FROM ${REGISTRY:-registry.mapotempo.com/}mapotempo-${BRANCH:-ce}/optimizer-ortools:${OPTIMIZER_ORTOOLS_VERSION:-v1.10.0}
 ARG BUNDLE_WITHOUT
 
 ENV LANG C.UTF-8

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,7 @@ Minitest::Retry.use!(
     DichotomiousTest#test_dichotomious_approach
     RealCasesTest#test_ortools_open_timewindows
     SplitClusteringTest#test_avoid_capacities_overlap
+    SplitClusteringTest#test_cluster_one_phase_vehicle
     SplitClusteringTest#test_instance_same_point_day
     SplitClusteringTest#test_no_doubles_3000
     WrapperTest#test_detecting_unfeasible_services_can_not_take_too_long

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -201,7 +201,7 @@ module TestHelper # rubocop: disable Style/CommentedKeyword, Lint/RedundantCopDi
 
             WebMock.enable_net_connect!
             matrices =
-              vrp.router.send(:__minitest_stub__matrix, url, mode, dimensions, row, column, options) # call original method
+              vrp.router.send(:__minitest_any_instance_stub__matrix, url, mode, dimensions, row, column, options) # call original method
             WebMock.disable_net_connect!
             write_in_dump <<
               { url: url, mode: mode, dimensions: dimensions, row: row, column: column, options: options, matrices: matrices }

--- a/wrappers/ortools.rb
+++ b/wrappers/ortools.rb
@@ -289,18 +289,16 @@ module Wrappers
       }
 
       vrp.relations.each{ |relation|
-        relation.split_regarding_lapses.flat_map{ |relation_portion|
-          portion_linked_ids, portion_vehicle_ids, portion_lapse = relation_portion
-
-          current_linked_ids = (portion_linked_ids & services.map(&:id)).uniq if portion_linked_ids
-          current_linked_vehicles = (portion_vehicle_ids & vehicles.map(&:id)).uniq if portion_vehicle_ids
+        relation.split_regarding_lapses.each{ |portion_linked_ids, portion_vehicle_ids, portion_lapse|
+          current_linked_ids = (portion_linked_ids.map!(&:to_s) & services.map(&:id)).uniq if portion_linked_ids
+          current_linked_vehicles = (portion_vehicle_ids.map!(&:to_s) & vehicles.map(&:id)).uniq if portion_vehicle_ids
           next if current_linked_ids.to_a.empty? && current_linked_vehicles.to_a.empty?
 
           # NOTE: we collect lapse because optimizer-ortools expects one lapse per relation for now
           relations << OrtoolsVrp::Relation.new(
             type: relation.type,
-            linked_ids: current_linked_ids&.map(&:to_s),
-            linked_vehicle_ids: current_linked_vehicles&.map(&:to_s),
+            linked_ids: current_linked_ids,
+            linked_vehicle_ids: current_linked_vehicles,
             lapse: portion_lapse
           )
         }

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -1112,6 +1112,8 @@ module Wrappers
             expanded_services << new_service
           }
 
+          # For some reason, or-tools performance is better when the sequence relation is defined in the inverse order.
+          # Note that, activity.duration's are set to zero except the last duplicated service (so we model exactly same constraint). 
           sequence_relations << Models::Relation.create(type: :sequence, linked_ids: sequence_relation_ids.reverse)
         }
 


### PR DESCRIPTION
Makes sure that simplified relations are not ignored in the protobuf collection.

- [x] It needs the following optimizer-ortools PR since simplified complex shipments are connected via `:sequence` relations and this PR fixes an issue with it https://github.com/Mapotempo/optimizer-ortools/pull/33

Closes optimizer-api/-/issues/882