### PR TITLE
Fix: periodic generate_tw handles TWs out of range

### DIFF
--- a/lib/interpreters/periodic_visits.rb
+++ b/lib/interpreters/periodic_visits.rb
@@ -67,7 +67,7 @@ module Interpreters
     def generate_timewindows(timewindows_set)
       return nil if timewindows_set.empty?
 
-      timewindows_set.collect{ |timewindow|
+      timewindows_set.flat_map{ |timewindow|
         if @have_day_index
           first_day =
             if timewindow.day_index
@@ -85,7 +85,7 @@ module Interpreters
         else
           timewindow
         end
-      }.flatten.sort_by(&:start).compact.uniq
+      }.compact.uniq.sort_by(&:start)
     end
 
     def generate_relations(vrp)

--- a/lib/interpreters/periodic_visits.rb
+++ b/lib/interpreters/periodic_visits.rb
@@ -85,7 +85,7 @@ module Interpreters
         else
           timewindow
         end
-      }.compact.uniq.sort_by(&:start)
+      }.compact.uniq{ |tw| tw.attributes.except(:id) }.sort_by(&:start)
     end
 
     def generate_relations(vrp)

--- a/test/lib/heuristics/periodic_functions_test.rb
+++ b/test/lib/heuristics/periodic_functions_test.rb
@@ -690,6 +690,22 @@ class HeuristicTest < Minitest::Test
                    'service_3 can no have a lapse multiple of 7, we can reject it immediatly'
     end
 
+    def test_generate_timewindows_with_extra_day_indices
+      vrp = TestHelper.create(VRP.periodic)
+      vrp.schedule_range_indices[:start] = 1 # schedule starts at 1 but there is a service tw with day_index = 0
+      vrp.schedule_range_indices[:end] = 2
+      vrp.vehicles = TestHelper.expand_vehicles(vrp)
+      periodic = Interpreters::PeriodicVisits.new(vrp)
+
+      periodic.instance_variable_set(:@have_day_index, true)
+
+      timewindows_set = Array.new(1){ |i|
+        Models::Timewindow.create(start: 0, end: 86400, day_index: i) # day_index 0
+      }
+
+      assert periodic.send(:generate_timewindows, timewindows_set) # should not raise
+    end
+
     def test_day_in_possible_interval
       vrp = TestHelper.create(VRP.periodic)
       vrp.services.first.visits_number = 4


### PR DESCRIPTION
Fixes api-optimizer-prod/issues/18745 