### PR TITLE
Allow quotas to become unlimited

### DIFF
--- a/api/v01/api.rb
+++ b/api/v01/api.rb
@@ -91,7 +91,7 @@ module Api
 
             quota.slice(:daily, :monthly, :yearly).each do |k, v|
               count = redis_count.get(count_base_key(op, k)).to_i
-              raise QuotaExceeded.new("Too many #{k} requests", limit: v, remaining: v - count, reset: k) if count + request_size > v
+              raise QuotaExceeded.new("Too many #{k} requests", limit: v, remaining: v - count, reset: k) if v && count + request_size > v
             end
           end
         end

--- a/config/access.rb
+++ b/config/access.rb
@@ -20,6 +20,7 @@ module OptimizerWrapper
     # params_limit and quota overload values from profile
     'demo' => { profile: :demo, params_limit: { points: nil, vehicles: nil }},
     'quota' => { profile: :demo, quotas: [{ operation: :optimize, daily: 4 }, { monthly: 6 }] },
+    'quota_nil' => { profile: :quotas, quotas: [{ operation: :optimize, daily: nil }] },
     'expired' => { profile: :standard, expire_at: '2000-01-01' },
     'solvers' => { profile: :solvers },
     'vroom' => { profile: :vroom },

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -96,6 +96,14 @@ module OptimizerWrapper
         params_limit: PARAMS_LIMIT,
         quotas: QUOTAS, # Only taken into account if REDIS_COUNT
       },
+      quotas: {
+        queue: 'DEFAULT',
+        services: {
+          vrp: [:ortools]
+        },
+        params_limit: PARAMS_LIMIT,
+        quotas: [{ daily: 10 }], # Only taken into account if REDIS_COUNT
+      }
     },
     solve: {
       synchronously: ENV['OPTIM_SOLVE_SYNCHRONOUSLY'] ? ENV['OPTIM_SOLVE_SYNCHRONOUSLY'] == 'true' : true,

--- a/test/api/v01/api_test.rb
+++ b/test/api/v01/api_test.rb
@@ -82,6 +82,16 @@ class Api::V01::ApiTest < Minitest::Test
     }.values
   end
 
+  def test_use_quota_nil
+    clear_optim_redis_count
+
+    # assert override 10 by nil (unlimited)
+    11.times do
+      post '/0.1/vrp/submit', { api_key: 'quota_nil', vrp: VRP.basic }.to_json, 'CONTENT_TYPE' => 'application/json'
+      assert last_response.ok?, last_response.body
+    end
+  end
+
   def test_use_specific_router_api_key
     s = stub_request(:post, %r{/0.1/matrix.json})
         .with(body: hash_including(api_key: 'other_key', mode: 'pedestrian', dimension: 'distance_time'))


### PR DESCRIPTION
Actually, when we want to set an unlimited quota with `nil` in api_key configuration, code fails.