### PR TITLE
Fix find_best_heuristic selection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ### Added
 
+
 ### Changed
+
 
 ### Removed
 
+
 ### Fixed
+
+- Fix find_best_heuristic selection logic [#337](https://github.com/Mapotempo/optimizer-api/pull/337)
 
 ## [v1.8.2] - 2022-01-19
 

--- a/lib/interpreters/compute_several_solutions.rb
+++ b/lib/interpreters/compute_several_solutions.rb
@@ -196,7 +196,8 @@ module Interpreters
         first_results.each_with_index{ |result, i|
           synthesis << {
             heuristic: custom_heuristics[i],
-            quality: result.nil? ? Float::MAX : result[:cost].to_i + (times[i] / 1000).to_i,
+            # If the cost is 0 we might want to set it to Float::MAX because 0 cost is not possible.
+            quality: result.nil? ? [Float::MAX] : [result[:unassigned]&.size.to_i, result[:cost].to_i, times[i]],
             used: false,
             cost: result ? result[:cost] : nil,
             time_spent: times[i],


### PR DESCRIPTION
The selection logic selects the worst/blocked heuristic which returns an all-unplanned solution.