### PR TITLE
Hotfix for split_independent_vrp and dichotomous

### DIFF
--- a/api/v01/entities/vrp_input.rb
+++ b/api/v01/entities/vrp_input.rb
@@ -185,6 +185,7 @@ module VrpConfiguration
     optional(:variation_ratio, type: Integer, desc: 'Value of the ratio that will change the matrice')
     optional(:repetition, type: Integer, documentation: { hidden: true }, desc: 'Number of times the optimization process is going to be repeated. Only the best solution is returned.')
     optional(:dicho_algorithm_service_limit, type: Integer, documentation: { hidden: true }, desc: 'Minimum number of services required to allow a call to heuristic dichotomious_approach')
+    optional(:dicho_inclusion_rate, type: Float, values: ->(v) { v > 0 }, documentation: { hidden: true }, desc: 'Approximate minimum load rate for the solver to consider using a vehicle')
     at_least_one_of :duration, :iterations, :iterations_without_improvment, :stable_iterations, :stable_coefficient, :initial_time_out, :minimum_duration
     mutually_exclusive :initial_time_out, :minimum_duration
     mutually_exclusive :solver, :solver_parameter

--- a/lib/interpreters/split_clustering.rb
+++ b/lib/interpreters/split_clustering.rb
@@ -22,14 +22,6 @@ require './lib/interpreters/periodic_visits.rb'
 
 module Interpreters
   class SplitClustering
-    # Relations that link multiple services to be on the same route
-    LINKING_RELATIONS = %i[
-      order
-      same_route
-      sequence
-      shipment
-      same_vehicle
-    ].freeze
     # Relations that force multiple services/vehicles to stay in the same VRP
     FORCING_RELATIONS = %i[
       maximum_day_lapse
@@ -1110,7 +1102,7 @@ module Interpreters
           # we can group services even if they have are in linking relations if everything else is the same
           linked_relation_details =
             if options[:group_points]
-              s.relations.select{ |r| LINKING_RELATIONS.include?(r.type) }.collect{ |relation|
+              s.relations.select{ |r| Models::Relation::LINKING_RELATIONS.include?(r.type) }.collect{ |relation|
                 relation.linked_services.collect{ |service|
                   rs_location = service.activity.point.location
                   [relation.type, rs_location.lat, rs_location.lon]
@@ -1203,8 +1195,8 @@ module Interpreters
           # well, then we need to check only the relations of a single service from each sub_set but
           # we need to make sure that we are checking the same relations in different sub_set. That
           # is why we do select a single service from each sub_set with max_by logic
-          service = sub_set.max_by{ |s| s.relations.max_by{ |r| LINKING_RELATIONS.include?(r.type) ? r.id : 0 }&.id.to_i }
-          service.relations.select{ |r| LINKING_RELATIONS.include?(r.type) }.each{ |relation|
+          service = sub_set.max_by{ |s| s.relations.max_by{ |r| Models::Relation::LINKING_RELATIONS.include?(r.type) ? r.id : 0 }&.id.to_i }
+          service.relations.select{ |r| Models::Relation::LINKING_RELATIONS.include?(r.type) }.each{ |relation|
             related_item_indices[relation] << index
           }
         }

--- a/models/configuration.rb
+++ b/models/configuration.rb
@@ -49,7 +49,7 @@ module Models
     field :dicho_division_service_limit, default: 100 # This variable needs to corrected using the average number of services per vehicle.
     field :dicho_division_vehicle_limit, default: 3
     field :dicho_exclusion_scaling_angle, default: 38
-    field :dicho_exclusion_rate, default: 0.6
+    field :dicho_inclusion_rate, default: 0.6
     field :dicho_algorithm_service_limit, default: 500 # This variable is exposed in a hidden way for studies
 
     field :duration, default: nil

--- a/models/relation.rb
+++ b/models/relation.rb
@@ -19,6 +19,17 @@ require './models/base'
 
 module Models
   class Relation < Base
+    ALL_OR_NONE_RELATIONS = %i[shipment sequence meetup].freeze
+
+    # Relations that link multiple services to be on the same route
+    LINKING_RELATIONS = %i[
+      order
+      same_route
+      same_vehicle
+      sequence
+      shipment
+    ].freeze
+
     NO_LAPSE_TYPES = %i[same_vehicle same_route sequence order shipment meetup force_first never_first force_end].freeze
     ONE_LAPSE_TYPES = %i[vehicle_group_number vehicle_group_duration vehicle_group_duration_on_weeks vehicle_group_duration_on_months].freeze
     SEVERAL_LAPSE_TYPES = %i[minimum_day_lapse maximum_day_lapse minimum_duration_lapse maximum_duration_lapse vehicle_trips].freeze

--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -727,7 +727,9 @@ module Models
         coeff_uniform_cost = tan_uniform / (1 - tan_variable * tan_uniform)
 
         services.each{ |service|
-          service.exclusion_cost = (coeff_variable_cost * (max_fixed_cost / exclusion_rate * service[:activity][:duration] / average_service_load) + coeff_uniform_cost * (max_fixed_cost / exclusion_rate)).ceil
+          service.exclusion_cost = (2**(4 - service.priority) * coeff_variable_cost *
+            (max_fixed_cost / exclusion_rate * service.activity.duration / average_service_load) +
+            coeff_uniform_cost * (max_fixed_cost / exclusion_rate)).ceil
         }
       when :distance
         raise 'Distance based exclusion cost calculation is not ready'

--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -52,7 +52,7 @@ module Models
     field :resolution_dicho_division_service_limit, default: 100 # This variable needs to corrected using the average number of services per vehicle.
     field :resolution_dicho_division_vehicle_limit, default: 3
     field :resolution_dicho_exclusion_scaling_angle, default: 38
-    field :resolution_dicho_exclusion_rate, default: 0.6
+    field :resolution_dicho_inclusion_rate, default: 0.6
 
     field :resolution_duration, default: nil
     field :resolution_total_duration, default: nil
@@ -621,6 +621,7 @@ module Models
       self.resolution_batch_heuristic = resolution[:batch_heuristic]
       self.resolution_repetition = resolution[:repetition]
       self.resolution_dicho_algorithm_service_limit = resolution[:dicho_algorithm_service_limit]
+      self.resolution_dicho_inclusion_rate = resolution[:dicho_inclusion_rate]
     end
 
     def preprocessing=(preprocessing)
@@ -704,7 +705,7 @@ module Models
                                          approximate_number_of_vehicles_used * 2 * Helper.flying_distance(average_loc, [depot.location.lat, depot.location.lon])
 
                                          # TODO: Here we use flying_distance for approx_depot_time_correction; however, this value is in terms of meters
-                                         # instead of seconds. Still since all dicho paramters    -- i.e.,  resolution_dicho_exclusion_scaling_angle, resolution_dicho_exclusion_rate, etc. --
+                                         # instead of seconds. Still since all dicho parameters    -- i.e.,  resolution_dicho_exclusion_scaling_angle, resolution_dicho_inclusion_rate, etc. --
                                          # are calculated with this functionality, correcting this bug makes the calculated parameters perform less effective.
                                          # We need to calculate new parameters after correcting the bug.
                                          #
@@ -719,8 +720,11 @@ module Models
 
         average_service_load = total_time_load / services.size.to_f
         average_number_of_services_per_vehicle = average_vehicles_work_time / average_service_load
-        exclusion_rate = resolution_dicho_exclusion_rate * average_number_of_services_per_vehicle
-        angle = resolution_dicho_exclusion_scaling_angle # It needs to be in between 0 and 45 - 0 means only uniform cost is used - 45 means only variable cost is used
+        inclusion_rate = resolution_dicho_inclusion_rate * average_number_of_services_per_vehicle
+        # Angle needs to be in between 0° and 45°:
+        # - 0°  means only uniform cost is used
+        # - 45° means only variable cost is used
+        angle = resolution_dicho_exclusion_scaling_angle
         tan_variable = Math.tan(angle * Math::PI / 180)
         tan_uniform = Math.tan((45 - angle) * Math::PI / 180)
         coeff_variable_cost = tan_variable / (1 - tan_variable * tan_uniform)
@@ -728,8 +732,8 @@ module Models
 
         services.each{ |service|
           service.exclusion_cost = (2**(4 - service.priority) * coeff_variable_cost *
-            (max_fixed_cost / exclusion_rate * service.activity.duration / average_service_load) +
-            coeff_uniform_cost * (max_fixed_cost / exclusion_rate)).ceil
+            (max_fixed_cost / inclusion_rate * service.activity.duration / average_service_load) +
+            coeff_uniform_cost * (max_fixed_cost / inclusion_rate)).ceil
         }
       when :distance
         raise 'Distance based exclusion cost calculation is not ready'

--- a/models/vrp.rb
+++ b/models/vrp.rb
@@ -241,6 +241,7 @@ module Models
       vrp.expand_unavailable_days
       vrp.provide_original_info # TODO: this should be done on hash in order to be sure to have the original information
       vrp.sticky_as_skills # TODO: this should be done on hash in order to completely remove sticky_vehicles from service model
+      vrp.accumulate_skills_of_services_in_linking_relations # WARN: needs to be after provide_original_info + sticky_as_skills
     end
 
     def self.convert_position_relations(hash)

--- a/optimizer_wrapper.rb
+++ b/optimizer_wrapper.rb
@@ -380,8 +380,12 @@ module OptimizerWrapper
   end
 
   def self.adjust_independent_duration(vrp, this_sub_size, total_size)
+    return unless total_size&.positive?
+
     split_ratio = this_sub_size.to_f / total_size
-    vrp.resolution_duration = vrp.resolution_duration&.*(split_ratio)&.ceil
+
+    vrp.resolution_duration =
+      vrp.resolution_duration&.*(split_ratio)&.ceil
     vrp.resolution_minimum_duration =
       vrp.resolution_minimum_duration&.*(split_ratio)&.ceil
     vrp.resolution_iterations_without_improvment =

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -2675,7 +2675,7 @@ class WrapperTest < Minitest::Test
   end
 
   def test_add_unassigned_respects_relations
-    assert_equal %i[shipment sequence meetup].sort, Wrappers::Wrapper::ALL_OR_NONE_RELATIONS.sort
+    assert_equal %i[shipment sequence meetup].sort, Models::Relation::ALL_OR_NONE_RELATIONS.sort
 
     problem = VRP.lat_lon
     service_zero = Oj.load(Oj.dump(problem[:services].first))
@@ -2688,7 +2688,7 @@ class WrapperTest < Minitest::Test
     assert_equal 1, services_demo.add_unassigned({}, vrp, vrp[:services][0], 'reason').values.flatten.size
 
     # all 7 services in one relation type become unfeasible at the same time
-    Wrappers::Wrapper::ALL_OR_NONE_RELATIONS.each{ |relation_type|
+    Models::Relation::ALL_OR_NONE_RELATIONS.each{ |relation_type|
       linked_ids_size = relation_type == :shipment ? 2 : problem[:services].size
       problem[:relations] = [{ type: relation_type, linked_ids: problem[:services][0..linked_ids_size-1].collect{ |s| s[:id] } }]
       vrp = TestHelper.create(problem)

--- a/wrappers/wrapper.rb
+++ b/wrappers/wrapper.rb
@@ -613,7 +613,6 @@ module Wrappers
       unfeasible
     end
 
-    ALL_OR_NONE_RELATIONS = %i[shipment sequence meetup].freeze
     def add_unassigned(unfeasible, vrp, service, reason)
       # calls add_unassigned_internal for every service in an "ALL_OR_NONE_RELATION" with the service
       service_already_marked_unfeasible = !!unfeasible[service.id]
@@ -624,7 +623,7 @@ module Wrappers
 
       unless service_already_marked_unfeasible
         service.relations.each{ |relation|
-          next unless ALL_OR_NONE_RELATIONS.include?(relation.type.to_sym) # TODO: remove to_sym when https://github.com/Mapotempo/optimizer-api/pull/145 is merged
+          next unless Models::Relation::ALL_OR_NONE_RELATIONS.include?(relation.type.to_sym) # TODO: remove to_sym when https://github.com/Mapotempo/optimizer-api/pull/145 is merged
 
           relation.linked_services&.each{ |service_in|
             next if service_in == service


### PR DESCRIPTION
- split_independent_vrp respects relations during the split 
- dichotomous takes priority into account during exclusion cost calculation