### PR TITLE
skip split_independent_vrp if forcing_relations

### DIFF
--- a/models/relation.rb
+++ b/models/relation.rb
@@ -30,6 +30,16 @@ module Models
       shipment
     ].freeze
 
+    # Relations that force multiple services/vehicles to stay in the same VRP
+    FORCING_RELATIONS = %i[
+      maximum_day_lapse
+      maximum_duration_lapse
+      meetup
+      minimum_day_lapse
+      minimum_duration_lapse
+      vehicle_trips
+    ].freeze
+
     NO_LAPSE_TYPES = %i[same_vehicle same_route sequence order shipment meetup force_first never_first force_end].freeze
     ONE_LAPSE_TYPES = %i[vehicle_group_number vehicle_group_duration vehicle_group_duration_on_weeks vehicle_group_duration_on_months].freeze
     SEVERAL_LAPSE_TYPES = %i[minimum_day_lapse maximum_day_lapse minimum_duration_lapse maximum_duration_lapse vehicle_trips].freeze

--- a/optimizer_wrapper.rb
+++ b/optimizer_wrapper.rb
@@ -404,6 +404,11 @@ module OptimizerWrapper
     mission_skills = vrp.services.map(&:skills).uniq
     return [vrp] if mission_skills.include?([])
 
+    if vrp.relations.any?{ |r| Models::Relation::FORCING_RELATIONS.include?(r.type) }
+      log 'split_independent_vrp does not support vehicle_trips and other FORCING_RELATIONS yet', level: :warn
+      return [vrp]
+    end
+
     # Generate Services data
     grouped_services = vrp.services.group_by(&:skills)
     skill_service_ids = Hash.new{ [] }

--- a/test/lib/interpreters/split_clustering_test.rb
+++ b/test/lib/interpreters/split_clustering_test.rb
@@ -676,7 +676,7 @@ class SplitClusteringTest < Minitest::Test
         minimum_day_lapse
         minimum_duration_lapse
         vehicle_trips
-      ], Interpreters::SplitClustering::FORCING_RELATIONS, 'Forcing relation constant has changed'
+      ], Models::Relation::FORCING_RELATIONS, 'Forcing relation constant has changed'
     end
 
     def test_collect_data_items_respects_linking_relations

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -2988,15 +2988,51 @@ class WrapperTest < Minitest::Test
     problem = VRP.independent_skills
 
     problem[:vehicles][1][:end_point_id] = problem[:vehicles].first[:start_point_id]
+    problem[:vehicles][1][:skills] = [[]] # vehicle_1
+
+    # WITHOUT vehicle_trips
+    vrp = TestHelper.create(problem)
+    independent_vrps = OptimizerWrapper.split_independent_vrp(vrp)
+    # 5 independent vrps
+    # one with v0
+    # one with v2
+    # one without vehicle for "infeasible" service_3
+    # one without vehicle for "infeasible" service_5 (this and the previous one can be in the same sub-vrp eventually)
+    # one with v1 and without services because it cannot serve any
+    assert_equal 5, independent_vrps.size,
+                 'split_independent_vrp function does not generate expected number of independent_vrps'
+
+    expected_vehicles = [["vehicle_0"], ["vehicle_2"], [], [], ["vehicle_1"]]
+    expected_services = [["service_2", "service_4"], ["service_1", "service_6"], ["service_3"], ["service_5"], []]
+    assert_equal expected_vehicles.sort, independent_vrps.map{ |i| i.vehicles.map(&:id) }.sort
+    assert_equal expected_services.sort, independent_vrps.map{ |i| i.services.map(&:id).sort }.sort
+
+    # INTERIM CHECK
     problem[:relations] = [{ type: :vehicle_trips, linked_vehicle_ids: ['vehicle_1', 'vehicle_2'] }]
     vrp = TestHelper.create(problem)
-
     independent_vrps = OptimizerWrapper.split_independent_vrp(vrp)
-    expected_skills_sets = [[[[:D, :S1]]], [[[:D, :S2]], [[:S3, :S4]]]]
-    assert_equal expected_skills_sets, independent_vrps.map{ |i| i.vehicles.map(&:skills).sort }.sort
+    msg = "Waiting for split_independent_vrp forcing relation implementation. This INTERIM CHECK part can be "\
+          "deleted upto the skip and the rest of the test with vehicle_trips can be activated."
+    assert_equal 1, independent_vrps.size,
+                 'split_independent_vrp function does not generate expected number of independent_vrps' + msg
+    skip msg
 
-    assert_equal 2, independent_vrps.size,
-                 'split_independent_vrp function does not generate expected number of independent_vrps'
+    # WITH vehicle_trips
+    problem[:relations] = [{ type: :vehicle_trips, linked_vehicle_ids: ['vehicle_1', 'vehicle_2'] }]
+    vrp = TestHelper.create(problem)
+    independent_vrps = OptimizerWrapper.split_independent_vrp(vrp)
+    # 4 independent vrps
+    # one with v0
+    # one with v1 and v2 (because of vehicle trips relation otherwise v1 would be in a separate "empty" sub-problem)
+    # one without vehicle for "infeasible" service_3
+    # one without vehicle for "infeasible" service_5 (this and the previous one can be in the same sub-vrp eventually)
+    assert_equal 4, independent_vrps.size,
+                'split_independent_vrp function does not generate expected number of independent_vrps'
+
+    expected_vehicles = [["vehicle_0"], ["vehicle_1", "vehicle_2"], [], []]
+    expected_services = [["service_2", "service_4"], ["service_1", "service_6"], ["service_3"], ["service_5"]]
+    assert_equal expected_vehicles.sort, independent_vrps.map{ |i| i.vehicles.map(&:id) }.sort
+    assert_equal expected_services.sort, independent_vrps.map{ |i| i.services.map(&:id).sort }.sort
   end
 
   def test_split_independent_vrps_with_useless_vehicle


### PR DESCRIPTION
Otherwise, split can violate such services and lead to incoherent results