### PR TITLE
Try to keep last result

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
         run: ./.github/actions/launch_stack.sh
         shell: bash
       - name: Starting tests
-        timeout-minutes: 25
+        timeout-minutes: 30
         run: ./.github/actions/tests.sh
         shell: bash
 

--- a/lib/heuristics/dichotomous_approach.rb
+++ b/lib/heuristics/dichotomous_approach.rb
@@ -213,8 +213,8 @@ module Interpreters
 
     def self.dicho_level_coeff(service_vrp)
       balance = 0.66666
-      level_approx = Math.log(service_vrp[:vrp].configuration.resolution.dicho_division_vehicle_limit /
-                    (service_vrp[:vrp].configuration.resolution.vehicle_limit || service_vrp[:vrp].vehicles.size).to_f, balance)
+      divisor = (service_vrp[:vrp].configuration.resolution.vehicle_limit || service_vrp[:vrp].vehicles.size).to_f
+      level_approx = Math.log(service_vrp[:vrp].configuration.resolution.dicho_division_vehicle_limit / divisor, balance)
       service_vrp[:vrp].configuration.resolution.dicho_level_coeff = 2**(1 / (level_approx - service_vrp[:dicho_level]).to_f)
     end
 

--- a/util/job_manager.rb
+++ b/util/job_manager.rb
@@ -91,7 +91,11 @@ module OptimizerWrapper
           }
           p[:graph] << { iteration: avancement, cost: cost, time: time }
           p[:result] = [solution.vrp_result].flatten if solution
-          Result.set(self.uuid, p)
+          begin
+            Result.set(self.uuid, p)
+          rescue Redis::BaseError => e
+            log "Could not set an intermediate result due to the following error: #{e}", level: :warning
+          end
         end
       }
       log "Ending job... #{options['checksum']}"


### PR DESCRIPTION
REDIS sometimes becomes unresponsive (this issue itself needs a deeper probe; however) when this happens if a worker tries to update the result (Result.set) or the advancement information then optimisation fails with 500 but it does not have to because if this is an intermediate solution -- i.e., if this is not the last result.set -- we do not care (that much) if the info is registered or not, we can just continue the optimisation and hope for the best that REDIS will become responsive again before we finish the optimisation. And if this is the last result to set, instead of failing wait for 2 minutes (this time can be increased/decreased -- or a complete exponential back-off logic can be implemented) and try one last time...

The issue is, once REDIS become unresponsive, all jobs fail and all workers start "bombarding" REDIS to check if there is a new job but since REDIS is unresponsive they fail and we end up with a loop of failing/restarting worker services. So here we try to prevent this. However, (except the fact that we should find out why REDIS becomes unresponsive) we also need this logic for `Resque::Plugins::Status` because Resque is the one bombarding redis with "is there a new job for me" questions in a loop -- if this logic was with exponential back-off (with a try-limit) -- this way we would not drop into the storm of restarting services. 

Basically all redis operations (especially get and set operations) in `.rbenv/versions/2.5.5/lib/ruby/gems/2.5.0/gems/resque-status-0.5.0/lib/resque/plugins/status/hash.rb`  needs exponential back-off logic.

Basically as explained in this Google page calling Redis memorystore directly is never safe https://cloud.google.com/memorystore/docs/redis/exponential-backoff -- unfortunately ruby client of redis does not implement exponential backoff automatically but there is a gem that we can try ... https://github.com/lantins/resque-retry

seen together with @alain-andre 