### PR TITLE
Setup for server performance comparison automation

### DIFF
--- a/api/v01/entities/vrp_input.rb
+++ b/api/v01/entities/vrp_input.rb
@@ -609,7 +609,7 @@ module VrpVehicles
     optional :width, type: Float, desc: 'Width in meters'
     optional :length, type: Float, desc: 'Length in meters'
     optional :hazardous_goods, type: Symbol, values: [:explosive, :gas, :flammable, :combustible, :organic, :poison, :radio_active, :corrosive, :poisonous_inhalation, :harmful_to_water, :other], desc: 'List of hazardous materials in the vehicle'
-    optional :max_walk_distance, type: Float, default: 750, desc: 'Max distance by walk'
+    optional :max_walk_distance, type: Float, default: 750.0, desc: 'Max distance by walk'
     optional :approach, type: Symbol, values: [:unrestricted, :curb], default: :unrestricted, desc: 'Arrive/Leave in the traffic direction'
     optional :snap, type: Float, desc: 'Snap waypoint to junction close by snap distance'
     optional :strict_restriction, type: Boolean, desc: 'Strict compliance with truck limitations'

--- a/test/api/v01/output_test.rb
+++ b/test/api/v01/output_test.rb
@@ -205,8 +205,8 @@ class Api::V01::OutputTest < Minitest::Test
     file = OutputHelper::Clustering.generate_files(all_services_vrps, true)
     generated_file = File.join(Api::V01::APIBase.dump_vrp_dir.cache, file)
 
-    assert File.exist?(generated_file + '_geojson'), 'Geojson file not found'
-    assert File.exist?(generated_file + '_csv'), 'Csv file not found'
+    assert File.exist?(generated_file + '_geojson.gz'), 'Geojson file not found'
+    assert File.exist?(generated_file + '_csv.gz'), 'Csv file not found'
     csv = CSV.parse(Api::V01::APIBase.dump_vrp_dir.read(file + '_csv'))
 
     assert_equal all_services_vrps.sum{ |service| service[:vrp].services.size } + 1, csv.size
@@ -221,8 +221,8 @@ class Api::V01::OutputTest < Minitest::Test
     file = OutputHelper::Clustering.generate_files(all_services_vrps)
     generated_file = File.join(Api::V01::APIBase.dump_vrp_dir.cache, file)
 
-    assert File.exist?(generated_file + '_geojson'), 'Geojson file not found'
-    assert File.exist?(generated_file + '_csv'), 'Csv file not found'
+    assert File.exist?(generated_file + '_geojson.gz'), 'Geojson file not found'
+    assert File.exist?(generated_file + '_csv.gz'), 'Csv file not found'
     csv = CSV.parse(Api::V01::APIBase.dump_vrp_dir.read(file + '_csv'))
 
     assert_equal all_services_vrps.sum{ |service| service[:vrp].services.size } + 1, csv.size
@@ -240,14 +240,14 @@ class Api::V01::OutputTest < Minitest::Test
     file = 'periodic_construction_test_fake_job'
     filepath = File.join(Api::V01::APIBase.dump_vrp_dir.cache, file)
 
-    refute File.exist?(filepath), 'File created before end of generation'
+    refute File.exist?(filepath + '.gz'), 'File created before end of generation'
 
     output_tool.add_comment('my comment')
     days = [0, 2, 4]
     output_tool.insert_visits(days, 'service_id', 3)
     output_tool.close_file
 
-    assert File.exist?(filepath), 'File not found'
+    assert File.exist?(filepath + '.gz'), 'File not found'
 
     csv = CSV.parse(Api::V01::APIBase.dump_vrp_dir.read(file))
     assert(csv.any?{ |line| line.first == 'my comment' })
@@ -291,9 +291,11 @@ class Api::V01::OutputTest < Minitest::Test
     files = Dir.glob(File.join(OptimizerWrapper.dump_vrp_dir.cache, "*#{name}*"))
 
     assert_equal 3, files.size
-    assert_includes files, File.join(OptimizerWrapper.dump_vrp_dir.cache, "periodic_construction_#{name}")
-    assert(files.any?{ |f| f.include?("generated_clusters_#{name}") && f.include?('csv') }, 'Geojson file not found')
-    assert(files.any?{ |f| f.include?("generated_clusters_#{name}") && f.include?('json') }, 'Csv file not found')
+    assert_includes files, File.join(OptimizerWrapper.dump_vrp_dir.cache, "periodic_construction_#{name}.gz")
+    assert(files.any?{ |f| f.end_with?('_csv.gz') && f.include?("generated_clusters_#{name}") },
+           'CSV file not found')
+    assert(files.any?{ |f| f.end_with?('_geojson.gz') && f.include?("generated_clusters_#{name}") },
+           'Geojson file not found')
   end
 
   def test_provided_language

--- a/util/job_manager.rb
+++ b/util/job_manager.rb
@@ -79,7 +79,7 @@ module OptimizerWrapper
 
       ask_restitution_csv = services_vrps.any?{ |s_v| s_v[:vrp].configuration.restitution.csv }
       ask_restitution_geojson = services_vrps.flat_map{ |s_v| s_v[:vrp].configuration.restitution.geometry }.uniq
-      final_solution =
+      final_solutions =
         OptimizerWrapper.define_main_process(
           services_vrps, self.uuid
         ) { |wrapper, avancement, total, message, cost, time, solution|
@@ -117,7 +117,7 @@ module OptimizerWrapper
           end
         }
       log "Ending job... #{options['checksum']}"
-      best_solution = final_solution.min(&:count_assigned_services)
+      best_solution = final_solutions.min(&:count_assigned_services)
       # WARNING: the following log is used for server performance comparison automation
       log "Elapsed time: #{(Time.now - job_started_at).round(2)}s Vrp size: #{services_vrps.size} "\
           "Key print: #{key_print} Names: #{services_vrps.map{ |sv| sv[:vrp].name }} "\
@@ -132,7 +132,7 @@ module OptimizerWrapper
         csv: ask_restitution_csv,
         geometry: ask_restitution_geojson
       }
-      p[:result] = final_solution.vrp_result
+      p[:result] = final_solutions.vrp_result
       if services_vrps.size == 1 && p && p[:result].any? && p[:graph]&.any?
         p[:result].first[:iterations] = p[:graph].last[:iteration]
         p[:result].first[:elapsed] = p[:graph].last[:time]

--- a/util/job_manager.rb
+++ b/util/job_manager.rb
@@ -117,8 +117,14 @@ module OptimizerWrapper
           end
         }
       log "Ending job... #{options['checksum']}"
+      best_solution = final_solution.min(&:count_assigned_services)
+      # WARNING: the following log is used for server performance comparison automation
       log "Elapsed time: #{(Time.now - job_started_at).round(2)}s Vrp size: #{services_vrps.size} "\
-          "Key print: #{key_print} Names: #{services_vrps.map{ |sv| sv[:vrp].name }}"
+          "Key print: #{key_print} Names: #{services_vrps.map{ |sv| sv[:vrp].name }} "\
+          "Checksum: #{options['checksum']} "\
+          "Assigned services: #{best_solution&.count_assigned_services} "\
+          "Unassigned services: #{best_solution&.count_unassigned_services} "\
+          "Used routes: #{best_solution&.count_used_routes}"
 
       # Add values related to the current solve status
       p = Result.get(self.uuid) || {}


### PR DESCRIPTION


- the checksum is calculated from the dumped/filtered vrp (so that all servers calculate the same SHA for the same vrp)
  - if the vpr_input parameters ever change then the calculated checksums will not match until the change propagates to all environments (to prevent the performance comparison automation breaking each time that happens we need to keep the original_vrp_checksum "trick" in the cron)
- files are dumped with gzip for easy decompression
- logs added to simplify perf comp automation